### PR TITLE
add support for long domain names in nginx

### DIFF
--- a/jobs/blobstore/templates/nginx.conf.erb
+++ b/jobs/blobstore/templates/nginx.conf.erb
@@ -12,6 +12,7 @@ events {
 http {
   include      /var/vcap/jobs/blobstore/config/mime.types;
   default_type text/html;
+  server_names_hash_bucket_size 128;
 
   log_format timed_combined '$remote_addr - $remote_user [$time_local] '
                             '"$request" $status $body_bytes_sent '


### PR DESCRIPTION
When we were using bosh-lite on AWS, our system domain was rather long
(stacks-cf-develop.buildpacks.ci.cf-app.com). When we deploy cf-release,
the blobstore failed the canary, after investigation we found the
following error in the nginx log.

> could not build the server_names_hash,
> you should increase server_names_hash_bucket_size: 32

We were able to create a shorter URL for our bosh deployment, but would
like to contribute this fix to resolve future issues.

More information about the attribute can be found
[here](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size).

Signed-off-by: Kelly Gerritz <kelly.gerritz@gmail.com>