### PR TITLE
Add a switch to control writing to /proc/sys

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -658,3 +658,7 @@ properties:
 
   dea_next.client_key:
     description: "PEM-encoded server key"
+
+  cc.core_file_pattern:
+    description: "Filename template for core dump files"
+    default: "/var/vcap/sys/cores/core-%e-%s-%p-%t"


### PR DESCRIPTION
Not all environments allow writing to /proc/sys, allow these to be
controlled via config setting.