### PR TITLE
Add hm9000.port to cloud_controller_ng/clock/worker spec

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -364,6 +364,8 @@ properties:
     description: "URL of the login server"
   hm9000.url:
     description: "URL of the hm9000 server"
+  hm9000.port:
+    description: "Port of the hm9000 Api Server"
 
   uaa.jwt.verification_key:
     default: ""

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -413,8 +413,11 @@ properties:
     default: "https"
   login.url:
     description: "URL of the login server"
+
   hm9000.url:
     description: "URL of the hm9000 server"
+  hm9000.port:
+    description: "Port of the hm9000 Api Server"
 
   uaa.jwt.verification_key:
     default: ""

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -369,6 +369,8 @@ properties:
     description: "URL of the login server"
   hm9000.url:
     description: "URL of the hm9000 server"
+  hm9000.port:
+    description: "Port of the hm9000 Api Server"
 
   uaa.jwt.verification_key:
     default: ""


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

Adds 'hm9000.port' to the specs for use in determining the correct internal address (separate PR for changes to cloud_controller_ng)

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run CF Acceptance Tests on bosh lite


[#118507195]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>