### PR TITLE
Add minimum candidate stagers to CC spec

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -632,6 +632,10 @@ properties:
     description: "The percentage of top stagers considered when choosing a stager"
     default: 10
 
+  cc.minimum_candidate_stagers:
+    description: "Minimum number of candidate deas for staging.  Defaults to 5, should be fewer than the total DEAs in the deployment."
+    default: 5
+
   router.route_services_secret:
     description: "Support for route services is disabled when no value is configured."
     default: ""


### PR DESCRIPTION
Expose the minimum_candidate_stagers config property in the CC spec

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run CF Acceptance Tests on bosh lite


[#119362989]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>