### PR TITLE
specify local to install bundler

### DIFF
--- a/packages/ruby-2.3/packaging
+++ b/packages/ruby-2.3/packaging
@@ -28,4 +28,4 @@ tar zxvf ruby-2.3/rubygems-${RUBYGEMS_VERSION}.tgz
   fi
 )
 
-${BOSH_INSTALL_TARGET}/bin/gem install ruby-2.3/bundler-${BUNDLER_VERSION}.gem --no-ri --no-rdoc
+${BOSH_INSTALL_TARGET}/bin/gem install ruby-2.3/bundler-${BUNDLER_VERSION}.gem --local --no-ri --no-rdoc


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
The bundler dependency should never have to come from rubygems.org, it should be available locally from blobs binaries upon compilation. This hasn't been an issue for CC specifically but it has been for other CF ruby components, see https://github.com/cloudfoundry/cf-release/pull/963 for reference.

* An explanation of the use cases your change solves
If an environment where I'm installing CF is not completely firewalled off from the internet, the compiler could in some situations believe that requests to rubygems.org are allowed, but not be able to download the necessary dependency. This prevents this from ever happening, by just grabbing local bits always.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run CF Acceptance Tests on bosh lite