### PR TITLE
Make consulTTL value configurable

### DIFF
--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -35,3 +35,8 @@ properties:
   capi.cc_uploader.cc.external_port:
     description: "External Cloud Controller port"
     default: 9022
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3
+

--- a/jobs/cc_uploader/templates/cc_uploader_as_vcap.erb
+++ b/jobs/cc_uploader/templates/cc_uploader_as_vcap.erb
@@ -11,6 +11,7 @@ exec /var/vcap/packages/cc_uploader/bin/cc-uploader \
   <% end %>\
   -dropsondePort=<%= p("capi.cc_uploader.dropsonde_port") %> \
   -skipCertVerify=<%= p("diego.ssl.skip_cert_verify") %> \
+  -consulTTL=<%= p("consul.ttl_in_seconds") %> \
   -logLevel=<%= p("capi.cc_uploader.log_level") %> \
   2> >(tee -a $LOG_DIR/cc_uploader.stderr.log | logger -p user.error -t vcap.cc-uploader) \
   1> >(tee -a $LOG_DIR/cc_uploader.stdout.log | logger -p user.info -t vcap.cc-uploader)

--- a/jobs/nsync/spec
+++ b/jobs/nsync/spec
@@ -90,3 +90,7 @@ properties:
   capi.nsync.diego_privileged_containers:
     description: "Whether or not to use privileged containers for  buildpack based LRPs and tasks. Containers with a docker-image-based rootfs will continue to always be unprivileged and cannot be changed."
     default: false
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/nsync/templates/nsync_listener_as_vcap.erb
+++ b/jobs/nsync/templates/nsync_listener_as_vcap.erb
@@ -32,6 +32,7 @@ exec /var/vcap/packages/nsync/bin/nsync-listener ${bbs_sec_flags} \
   -debugAddr=<%= p("capi.nsync.listener_debug_addr") %> \
   <%= p("capi.nsync.lifecycle_bundles").map { |bundle| "-lifecycle #{bundle}" }.join(" ") %> \
   -fileServerURL=<%= p("capi.nsync.file_server_url") %> \
+  -consulTTL=<%= p("consul.ttl_in_seconds") %> \
   -logLevel=<%= p("capi.nsync.log_level") %> \
   2> >(tee -a $LOG_DIR/nsync_listener.stderr.log | logger -p user.error -t vcap.nsync-listener) \
   1> >(tee -a $LOG_DIR/nsync_listener.stdout.log | logger -p user.info -t vcap.nsync-listener)

--- a/jobs/stager/spec
+++ b/jobs/stager/spec
@@ -88,3 +88,7 @@ properties:
   capi.stager.diego_privileged_containers:
     description: "Whether or not to use privileged containers for staging tasks."
     default: false
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/stager/templates/stager_as_vcap.erb
+++ b/jobs/stager/templates/stager_as_vcap.erb
@@ -38,6 +38,7 @@ exec /var/vcap/packages/stager/bin/stager ${bbs_sec_flags} \
   -ccUploaderURL=<%= p("capi.stager.cc_uploader_url") %> \
   -consulCluster=http://127.0.0.1:<%= p("capi.stager.consul_agent_port") %> \
   -dockerRegistryAddress=<%= p("capi.stager.docker_registry_address") %> \
+  -consulTTL=<%= p("consul.ttl_in_seconds") %> \
   <% p("capi.stager.insecure_docker_registry_list").each do |url| %> \
     -insecureDockerRegistry=<%= url %> \
   <% end %> \

--- a/jobs/tps/spec
+++ b/jobs/tps/spec
@@ -73,3 +73,7 @@ properties:
   capi.tps.watcher.debug_addr:
     description: "address at which to serve debug info"
     default: "0.0.0.0:17015"
+
+  consul.ttl_in_seconds:
+    description: "TTL value for consul registration in seconds"
+    default: 3

--- a/jobs/tps/templates/tps_listener_as_vcap.erb
+++ b/jobs/tps/templates/tps_listener_as_vcap.erb
@@ -31,5 +31,6 @@ exec /var/vcap/packages/tps/bin/tps-listener ${bbs_sec_flags} \
   -logLevel=<%= p("capi.tps.log_level") %> \
   -trafficControllerURL=<%= p("capi.tps.traffic_controller_url") %> \
   -skipSSLVerification=<%= p("diego.ssl.skip_cert_verify") %> \
+  -consulTTL=<%= p("consul.ttl_in_seconds") %> \
   2> >(tee -a $LOG_DIR/tps_listener.stderr.log | logger -p user.error -t vcap.tps-listener) \
   1> >(tee -a $LOG_DIR/tps_listener.stdout.log | logger -p user.info -t vcap.tps-listener)


### PR DESCRIPTION
- The default TTL value of 3 seconds results in a poll interval for 1.5 seconds for consul healthchecks.
  with all the diego components behaving this way, the consul in PCF Dev gets overloaded and goes unresponsive.
  PCF Dev needs this value to be increased/configurable.

This became necessary when these services switch from using `dns_health_check` to the TTL method. When the `dns_health_check` does not succeed within the TTL, consul will still respond to DNS queries for that service. Using the new TTL method, consul will unregister the service from it's DNS registry if it fails to update it's healthcheck status within the TTL.

This depends on:
https://github.com/cloudfoundry/cc-uploader/pull/1
https://github.com/cloudfoundry/nsync/pull/12
https://github.com/cloudfoundry/stager/pull/13
https://github.com/cloudfoundry/tps/pull/7

Signed-off-by: Anthony Emengo aemengo@pivotal.io
Signed-off-by: Mark DeLillo mdelillo@pivotal.io
- [ x] I have viewed signed and have submitted the Contributor License Agreement
- [ x] I have made this pull request to the `master` branch
- [ x] I have run CF Acceptance Tests on bosh lite
