### PR TITLE
Enable PUT requests on signed URLs

### DIFF
--- a/jobs/blobstore/templates/blobstore.conf.erb
+++ b/jobs/blobstore/templates/blobstore.conf.erb
@@ -62,6 +62,29 @@ server {
 
     alias /var/vcap/store/shared/;
   }
+
+  # ensure the contents of this location block always match the public server /write/ location block
+  location /write/ {
+    dav_methods PUT;
+    create_full_put_path on;
+
+    if ( $request_method !~ ^(PUT)$ ) {
+      return 405;
+    }
+
+    secure_link $arg_md5,$arg_expires;
+    secure_link_md5 "$secure_link_expires$uri <%= p('blobstore.secure_link.secret') %>";
+
+    if ($secure_link = "") {
+      return 403;
+    }
+
+    if ($secure_link = "0") {
+      return 410;
+    }
+
+    alias /var/vcap/store/shared/;
+  }
 }
 
 # Public server
@@ -76,6 +99,29 @@ server {
   # ensure the contents of this location block always match the internal server /read/ location block
   location /read/ {
     if ( $request_method !~ ^(GET|HEAD)$ ) {
+      return 405;
+    }
+
+    secure_link $arg_md5,$arg_expires;
+    secure_link_md5 "$secure_link_expires$uri <%= p('blobstore.secure_link.secret') %>";
+
+    if ($secure_link = "") {
+      return 403;
+    }
+
+    if ($secure_link = "0") {
+      return 410;
+    }
+
+    alias /var/vcap/store/shared/;
+  }
+
+  # ensure the contents of this location block always match the internal server /write/ location block
+  location /write/ {
+    dav_methods PUT;
+    create_full_put_path on;
+
+    if ( $request_method !~ ^(PUT)$ ) {
       return 405;
     }
 


### PR DESCRIPTION
/cc @smoser-ibm 

* A short explanation of the proposed change:

    Extend the blobstore job to allow PUT requests on pre-signed URLs. This is a minimal change to discuss the usefulness of this feature. That means, the `/read/` path is obviously misleading when talking about a pre-signed URL used together with a PUT request, but made it possible to add this feature without much effort. To improve this, one could (a) either change that to say `/signed/`, or (b) introduce completely new pre-signed URLs using `/write/` which then also only allow PUT requests, while the `/read/` only allow GET/HEAD requests. To unblock us, the current PR is the most helpful though. Please advice.

* An explanation of the use cases your change solves

    We currently use the WebDAV blobstore as one possible backend for the bits-service. For the new protocol, it will be necessary to hand out a pre-signed URL to the client, to which it can PUT the bits. While we could roll our own WebDAV blobstore (by forking the one from CAPI), that would be counterproductive and could potentially introduce migration issues in the future.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run CF Acceptance Tests on bosh lite


