### PR TITLE
Fixed the YAML submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -146,4 +146,4 @@
 	branch = master
 [submodule "src/gopkg.in/yaml.v2"]
 	path = src/gopkg.in/yaml.v2
-	url = https://github.com/go-yaml/yaml/
+	url = https://github.com/go-yaml/yaml


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Fixed the submodule URL for the YAML go package

* An explanation of the use cases your change solves
Git was complaining when syncing the submodule with trailing slash in the URL

Signed-off-by: Konstantin Semenov <ksemenov@pivotal.io>