### PR TITLE
Require to make PRs against develop, not master

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Thanks for contributing to the `capi_release`. To speed up the process of review
 
 * [ ] I have viewed signed and have submitted the Contributor License Agreement
 
-* [ ] I have made this pull request to the `master` branch
+* [ ] I have made this pull request to the `develop` branch
 
 * [ ] I have run CF Acceptance Tests on bosh lite
-


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    Change PR template to reflect current practices in the Capi team.

* An explanation of the use cases your change solves

    Less comments in future PRs.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

    _No. Made against `develop` :-)_

* [ ] I have run CF Acceptance Tests on bosh lite

    _Not necessary._
