### PR TITLE
Generaline running_in_container function

### DIFF
--- a/src/capi_utils/container_utils.sh
+++ b/src/capi_utils/container_utils.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 running_in_container() {
-  grep -q -E '/instance|/docker/' /proc/self/cgroup
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
 }
 


### PR DESCRIPTION
This change allows jobs to run correctly in garden-runc containers as well as in the previously supported garden-linux and docker containers.

See also https://github.com/cloudfoundry/cf-release/pull/1130, https://github.com/cloudfoundry/diego-release/pull/242, https://github.com/cloudfoundry-incubator/routing-release/issues/56 + related discussion on https://www.pivotaltracker.com/story/show/135771525.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
