### PR TITLE
signer_ctl.sh.erb: shellescape secure link secret

### DIFF
--- a/jobs/blobstore/templates/signer_ctl.sh.erb
+++ b/jobs/blobstore/templates/signer_ctl.sh.erb
@@ -19,8 +19,9 @@ case $1 in
 
     echo $$ > $PIDFILE
 
+    <% require "shellwords" %>
     exec chpst -u vcap:vcap /var/vcap/packages/blobstore_url_signer/blobstore_url_signer \
-      -secret <%=p("blobstore.secure_link.secret")%> \
+      -secret <%= Shellwords.shellescape(p("blobstore.secure_link.secret")) %> \
       -network unix \
       -laddr $SOCKETFILE \
       >>$LOG_DIR/blobstore_url_signer.stdout.log \


### PR DESCRIPTION
Deploy fails if `blobstore.secure_link.secret` has special BASH characters

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite