### PR TITLE
Execute bpm from /var/vcap/jobs/bpm/bin

### DIFF
--- a/jobs/blobstore/monit
+++ b/jobs/blobstore/monit
@@ -1,14 +1,14 @@
 <% if p("bpm.enabled") %>
 check process blobstore_nginx
   with pidfile /var/vcap/sys/run/bpm/blobstore/nginx.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start blobstore -p nginx"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop blobstore -p nginx"
+  start program "/var/vcap/jobs/bpm/bin/bpm start blobstore -p nginx"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop blobstore -p nginx"
   group vcap
 
  check process blobstore_url_signer
    with pidfile /var/vcap/sys/run/bpm/blobstore/url_signer.pid
-   start program "/var/vcap/packages/bpm/bin/bpm start blobstore -p url_signer"
-   stop program "/var/vcap/packages/bpm/bin/bpm stop blobstore -p url_signer"
+   start program "/var/vcap/jobs/bpm/bin/bpm start blobstore -p url_signer"
+   stop program "/var/vcap/jobs/bpm/bin/bpm stop blobstore -p url_signer"
    group vcap
 <% else %>
 check process blobstore_nginx

--- a/jobs/cc_uploader/monit
+++ b/jobs/cc_uploader/monit
@@ -1,8 +1,8 @@
 <% if p("bpm.enabled") %>
 check process cc_uploader
   with pidfile /var/vcap/sys/run/bpm/cc_uploader/cc_uploader.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cc_uploader"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cc_uploader"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cc_uploader"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cc_uploader"
   group vcap
 <% else %>
 check process cc_uploader

--- a/jobs/nsync/monit
+++ b/jobs/nsync/monit
@@ -1,14 +1,14 @@
 <% if p("bpm.enabled") %>
 check process nsync_listener
   with pidfile /var/vcap/sys/run/bpm/nsync/listener.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start nsync -p listener"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop nsync -p listener"
+  start program "/var/vcap/jobs/bpm/bin/bpm start nsync -p listener"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop nsync -p listener"
   group vcap
 
 check process nsync_bulker
   with pidfile /var/vcap/sys/run/bpm/nsync/bulker.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start nsync -p bulker"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop nsync -p bulker"
+  start program "/var/vcap/jobs/bpm/bin/bpm start nsync -p bulker"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop nsync -p bulker"
   group vcap
 <% else %>
 check process nsync_listener

--- a/jobs/stager/monit
+++ b/jobs/stager/monit
@@ -1,8 +1,8 @@
 <% if p("bpm.enabled") %>
 check process stager
   with pidfile /var/vcap/sys/run/bpm/stager/stager.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start stager"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop stager"
+  start program "/var/vcap/jobs/bpm/bin/bpm start stager"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop stager"
   group vcap
 <% else %>
 check process stager

--- a/jobs/tps/monit
+++ b/jobs/tps/monit
@@ -2,14 +2,14 @@
 <% if p('capi.tps.listener_enabled') %>
 check process tps_listener
   with pidfile /var/vcap/sys/run/bpm/tps/listener.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start tps -p listener"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop tps -p listener"
+  start program "/var/vcap/jobs/bpm/bin/bpm start tps -p listener"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop tps -p listener"
   group vcap
 <% end %>
 check process tps_watcher
   with pidfile /var/vcap/sys/run/bpm/tps/watcher.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start tps -p watcher"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop tps -p watcher"
+  start program "/var/vcap/jobs/bpm/bin/bpm start tps -p watcher"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop tps -p watcher"
   group vcap
 <% else %>
 


### PR DESCRIPTION
This is the recommended approach suggested by BOSH as /var/vcap/packages should
only be used internally by the job that provides them.  For more
information see: https://www.pivotaltracker.com/story/show/150503041