### PR TITLE
Stop trying to install bundler during pre-packaging

### DIFF
--- a/packages/nginx_newrelic_plugin/pre_packaging
+++ b/packages/nginx_newrelic_plugin/pre_packaging
@@ -5,10 +5,7 @@ pushd ${BUILD_DIR}/nginx
 popd
 
 pushd ${BUILD_DIR}/nginx/newrelic_nginx_agent
-	# bundler 1.12.x has a bug with caching built-in libraries
-	# https://github.com/bundler/bundler/issues/4494
-	gem install bundler -v 1.11.2
-	BUNDLE_WITHOUT=development:test bundle _1.11.2_ package --all --no-install --path ./vendor/cache
+	BUNDLE_WITHOUT=development:test bundle package --all --no-install --path ./vendor/cache
 
 	rm -rf ./vendor/cache/ruby
 	rm -rf ./vendor/cache/vendor


### PR DESCRIPTION
- pre-packaging runs on the user's workstation when building the
  release, so installing gems into the user's system isn't ideal
- On my Linux workstation, I have install gems using sudo and
  `sudo bosh create-release` is real sketchy
- The bug that caused capi to pin bundler to 1.11 has since been fixed
