### PR TITLE
add windows2016 as a default stack

### DIFF
--- a/jobs/nsync/spec
+++ b/jobs/nsync/spec
@@ -61,6 +61,7 @@ properties:
     default:
       - "buildpack/cflinuxfs2:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       - "buildpack/windows2012R2:windows_app_lifecycle/windows_app_lifecycle.tgz"
+      - "buildpack/windows2016:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       - "docker:docker_app_lifecycle/docker_app_lifecycle.tgz"
   capi.nsync.cc.base_url:
     description: base URL of the cloud controller

--- a/jobs/stager/spec
+++ b/jobs/stager/spec
@@ -71,6 +71,7 @@ properties:
     default:
       - "buildpack/cflinuxfs2:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       - "buildpack/windows2012R2:windows_app_lifecycle/windows_app_lifecycle.tgz"
+      - "buildpack/windows2016:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       - "docker:docker_app_lifecycle/docker_app_lifecycle.tgz"
   capi.stager.debug_addr:
     description: "address at which to serve debug info"


### PR DESCRIPTION
This PR adds the `windows2016` stack as a default stack (akin to `cflinuxfs2` and `windows2012R2` stacks) and the Buildpack App Lifecycle as its app lifecycle.

**Note:** This PR and the PR to `cloud_controller_ng` may touch some deprecated or soon to be deprecated components. We just added the `windows2016` stack everywhere `windows2012R2` was configured so let us know if some of these additions don't make sense and we can remove changes that are unnecessary.

Goes with https://github.com/cloudfoundry/cloud_controller_ng/pull/891