### PR TITLE
Remove namespacing of release_level_backup property

### DIFF
--- a/jobs/blobstore/spec
+++ b/jobs/blobstore/spec
@@ -72,7 +72,7 @@ properties:
     description: "Number of NGINX worker processes per CPU core"
     default: 2
 
-  blobstore.release_level_backup:
+  release_level_backup:
     description: "toggle to enable backups of the blobstore with bbr"
     default: false
 

--- a/jobs/blobstore/templates/backup
+++ b/jobs/blobstore/templates/backup
@@ -4,6 +4,6 @@ set -ex
 
 BOSH_DATA_DIRECTORY=${BOSH_DATA_DIRECTORY:-/var/vcap/store}
 
-<% if p('blobstore.release_level_backup') %>
+<% if p('release_level_backup') %>
   cp --recursive --link $BOSH_DATA_DIRECTORY/shared $BBR_ARTIFACT_DIRECTORY
 <% end %>

--- a/jobs/blobstore/templates/restore
+++ b/jobs/blobstore/templates/restore
@@ -6,7 +6,7 @@ BOSH_DATA_DIRECTORY=${BOSH_DATA_DIRECTORY:-/var/vcap/store}
 BACKUP_DIRECTORY="$BBR_ARTIFACT_DIRECTORY"/shared
 BLOBS_DIRECTORY="$BOSH_DATA_DIRECTORY"/shared
 
-<% if p('blobstore.release_level_backup') %>
+<% if p('release_level_backup') %>
   rm -rf ${BLOBS_DIRECTORY}
   cp --recursive ${BACKUP_DIRECTORY} ${BOSH_DATA_DIRECTORY}
 


### PR DESCRIPTION
[#151210351]

* A short explanation of the proposed change:
We discovered that the convention is not to namespace new job-level properties with the job name, so we are modifying the property we added in a previous pull request (from tinygrasshopper)

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/56 <- original pull request, recently merged

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
