### PR TITLE
Update BPM to 0.2.0

### DIFF
--- a/jobs/blobstore/templates/bpm.yml.erb
+++ b/jobs/blobstore/templates/bpm.yml.erb
@@ -1,12 +1,16 @@
 ---
 processes:
-  nginx:
-    executable: /var/vcap/jobs/blobstore/bin/blobstore_nginx
-    volumes:
-      - /var/vcap/store/shared
-  url_signer:
-    executable: /var/vcap/packages/blobstore_url_signer/blobstore_url_signer
-    args:
-      - --secret=<%= p("blobstore.secure_link.secret") %>
-      - --network=unix
-      - --laddr=/var/vcap/data/blobstore/signer.sock
+- name: nginx
+  executable: /var/vcap/jobs/blobstore/bin/blobstore_nginx
+  additional_volumes:
+    - path: /var/vcap/store/shared
+      writable: true
+  ephemeral_disk: true
+  persistent_disk: true
+- name: url_signer
+  executable: /var/vcap/packages/blobstore_url_signer/blobstore_url_signer
+  ephemeral_disk: true
+  args:
+    - --secret=<%= p("blobstore.secure_link.secret") %>
+    - --network=unix
+    - --laddr=/var/vcap/data/blobstore/signer.sock

--- a/jobs/cc_uploader/templates/bpm.yml.erb
+++ b/jobs/cc_uploader/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  cc_uploader:
-    executable: /var/vcap/packages/cc_uploader/bin/cc-uploader
-    args:
-      - --configPath=/var/vcap/jobs/cc_uploader/config/cc_uploader_config.json
-    limits:
-      open_files: 100000
+- name: cc_uploader
+  executable: /var/vcap/packages/cc_uploader/bin/cc-uploader
+  args:
+    - --configPath=/var/vcap/jobs/cc_uploader/config/cc_uploader_config.json
+  limits:
+    open_files: 100000

--- a/jobs/nsync/templates/bpm.yml.erb
+++ b/jobs/nsync/templates/bpm.yml.erb
@@ -1,12 +1,12 @@
 ---
 processes:
-  bulker:
-    executable: /var/vcap/packages/nsync/bin/nsync-bulker
-    args:
-      - --configPath=/var/vcap/jobs/nsync/config/nsync_bulker_config.json
-  listener:
-    executable: /var/vcap/packages/nsync/bin/nsync-listener
-    args:
-      - --configPath=/var/vcap/jobs/nsync/config/nsync_listener_config.json
-    limits:
-      open_files: 100000
+- name: bulker
+  executable: /var/vcap/packages/nsync/bin/nsync-bulker
+  args:
+    - --configPath=/var/vcap/jobs/nsync/config/nsync_bulker_config.json
+- name: listener
+  executable: /var/vcap/packages/nsync/bin/nsync-listener
+  args:
+    - --configPath=/var/vcap/jobs/nsync/config/nsync_listener_config.json
+  limits:
+    open_files: 100000

--- a/jobs/stager/templates/bpm.yml.erb
+++ b/jobs/stager/templates/bpm.yml.erb
@@ -1,8 +1,8 @@
 ---
 processes:
-  stager:
-    executable: /var/vcap/packages/stager/bin/stager
-    args:
-      - --configPath=/var/vcap/jobs/stager/config/stager_config.json
-    limits:
-      open_files: 100000
+- name: stager
+  executable: /var/vcap/packages/stager/bin/stager
+  args:
+    - --configPath=/var/vcap/jobs/stager/config/stager_config.json
+  limits:
+    open_files: 100000

--- a/jobs/tps/templates/bpm.yml.erb
+++ b/jobs/tps/templates/bpm.yml.erb
@@ -1,12 +1,12 @@
 ---
 processes:
-  listener:
-    executable: /var/vcap/packages/tps/bin/tps-listener
-    args:
-      - --configPath=/var/vcap/jobs/tps/config/tps_listener_config.json
-    limits:
-      open_files: 100000
-  watcher:
-    executable: /var/vcap/packages/tps/bin/tps-watcher
-    args:
-      - --configPath=/var/vcap/jobs/tps/config/tps_watcher_config.json
+- name: listener
+  executable: /var/vcap/packages/tps/bin/tps-listener
+  args:
+    - --configPath=/var/vcap/jobs/tps/config/tps_listener_config.json
+  limits:
+    open_files: 100000
+- name: watcher
+  executable: /var/vcap/packages/tps/bin/tps-watcher
+  args:
+    - --configPath=/var/vcap/jobs/tps/config/tps_watcher_config.json

--- a/jobs/tps/templates/tps_listener_ctl.erb
+++ b/jobs/tps/templates/tps_listener_ctl.erb
@@ -2,7 +2,6 @@
 
 RUN_DIR=/var/vcap/sys/run/tps
 LOG_DIR=/var/vcap/sys/log/tps
-DATA_DIR=/var/vcap/data/tps
 
 PIDFILE=$RUN_DIR/tps_listener.pid
 
@@ -18,13 +17,6 @@ case $1 in
 
     mkdir -p $LOG_DIR
     chown -R vcap:vcap $LOG_DIR
-
-    mkdir -p $DATA_DIR
-    chown -R vcap:vcap $DATA_DIR
-
-    depot=$DATA_DIR/depot
-
-    mkdir -p $DATA_DIR/depot
 
     echo $$ > $PIDFILE
 


### PR DESCRIPTION
*Note*: This PR should **NOT** be merged until BPM version `0.2.0` is on [release-candidate of cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/release-candidate/operations/experimental/enable-bpm.yml#L8)

This change set entails all the configuration changes necessary to migrate from BPM v0.1.0 to v0.2.0.

Configuration changes include:
- [Environment variables as a hash](https://www.pivotaltracker.com/story/show/151345092)
- [Processes as an array](https://www.pivotaltracker.com/story/show/151451341)
- [Volumes are read only by default](https://www.pivotaltracker.com/story/show/151408169)
- [Rename Volumes to AdditionalVolumes](https://www.pivotaltracker.com/story/show/151531845)
- [Opting into persistent volumes being mounted](https://www.pivotaltracker.com/story/show/151531925)
- [Opting into ephemeral volumes being mounted](https://www.pivotaltracker.com/story/show/151532030)

Signed-off-by: Julien Cherry <jcherry@pivotal.io>

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
