### PR TITLE
Increase timeout to prevent errors copying

### DIFF
--- a/jobs/nfs_mounter/templates/handle_nfs_blobstore.sh.erb
+++ b/jobs/nfs_mounter/templates/handle_nfs_blobstore.sh.erb
@@ -19,9 +19,9 @@ mount_nfs() {
 
   echo "Mounting NFS..."
   <% if properties.nfs_server.nfsv4 %>
-  mount --verbose -o timeo=10,intr,lookupcache=positive,soft -t nfs4 <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/" %> $NFS_SHARE
+  mount --verbose -o timeo=100,intr,lookupcache=positive,soft -t nfs4 <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/" %> $NFS_SHARE
   <% else %>
-  mount --verbose -o timeo=10,intr,lookupcache=positive,soft -t nfs <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/var/vcap/store" %> $NFS_SHARE
+  mount --verbose -o timeo=100,intr,lookupcache=positive,soft -t nfs <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/var/vcap/store" %> $NFS_SHARE
   <% end %>
   if [ $? != 0 ]; then
     echo "Cannot mount NFS, exiting..."

--- a/jobs/nfs_mounter/templates/handle_nfs_blobstore.sh.erb
+++ b/jobs/nfs_mounter/templates/handle_nfs_blobstore.sh.erb
@@ -19,9 +19,9 @@ mount_nfs() {
 
   echo "Mounting NFS..."
   <% if properties.nfs_server.nfsv4 %>
-  mount --verbose -o timeo=100,intr,lookupcache=positive,soft -t nfs4 <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/" %> $NFS_SHARE
+  mount --verbose -o timeo=600,intr,lookupcache=positive,soft -t nfs4 <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/" %> $NFS_SHARE
   <% else %>
-  mount --verbose -o timeo=100,intr,lookupcache=positive,soft -t nfs <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/var/vcap/store" %> $NFS_SHARE
+  mount --verbose -o timeo=600,intr,lookupcache=positive,soft -t nfs <%= properties.nfs_server.address %>:<%= properties.nfs_server.share || "/var/vcap/store" %> $NFS_SHARE
   <% end %>
   if [ $? != 0 ]; then
     echo "Cannot mount NFS, exiting..."


### PR DESCRIPTION
NFS low timeout causes: \"Permission denied @ rb_sysopen - /var/vcap/nfs/shared/cc-buildpacks/8d/3c/8d3ccb97-5fb2-4885-acb6-0c31a968c0ce_21be9f1ab8ce3cc605c07bc6196aa970a3cf83255b3f4ce98fe5d4673e4a9edf\", \"error_code\"=>\"CF-EACCES\"

We found increasing the timeout seemed to resolve this: 
https://github.com/cloudfoundry/cloud_controller_ng/issues/934

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
