### PR TITLE
BPM uses the same monit config as non-BPM

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -19,11 +19,15 @@
 %>
 
 <% if p("bpm.enabled") %>
+
 check process cloud_controller_ng
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng"
   group vcap
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
+  if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
 <% if p('cc.nginx.ip').empty? %>
   if failed host <%= discover_external_ip %> port <%= p("cc.external_port") %> protocol http
 <% else %>
@@ -39,6 +43,9 @@ check process cloud_controller_worker_local_<%= index %>
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p local_worker_<%= index %>"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p local_worker_<%= index %>"
   group vcap
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then restart
+  if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then restart
 <% end %>
 
 check process nginx_cc

--- a/jobs/cloud_controller_ng/templates/restart_drain.rb
+++ b/jobs/cloud_controller_ng/templates/restart_drain.rb
@@ -7,7 +7,12 @@ require 'cloud_controller/drain'
 
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cloud_controller_ng')
 @drain.log_invocation(ARGV)
+<% if p("bpm.enabled") %>
+@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid')
+@drain.shutdown_cc('/var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid')
+<% else %>
 @drain.shutdown_nginx('/var/vcap/sys/run/nginx_cc/nginx.pid')
 @drain.shutdown_cc('/var/vcap/sys/run/cloud_controller_ng/cloud_controller_ng.pid')
+<% end %>
 
 puts 0 # tell bosh the drain script succeeded


### PR DESCRIPTION
* Add `totalmem` stanzas to cc_ng and cc_ng_worker processes
* Update restart_drain.rb to be BPM aware (PID file location changes)

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This ensures that monit settings are the same when running with `bpm.enabled`

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
