### PR TITLE
Adds cc.tls_port to provided link property

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -66,6 +66,7 @@ provides:
   properties:
   - system_domain
   - app_domains
+  - cc.tls_port
 - name: cloud_controller_db
   type: cloud_controller_db
   properties:


### PR DESCRIPTION
As a consumer of the internal TLS API, I would like to ensure that I hit the correct port.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
