### PR TITLE
Export location of stacks.yml for migrations

### DIFF
--- a/jobs/cloud_controller_ng/templates/migrate_db.sh.erb
+++ b/jobs/cloud_controller_ng/templates/migrate_db.sh.erb
@@ -5,6 +5,7 @@ set -x
 
 CC_PACKAGE_DIR="/var/vcap/packages/cloud_controller_ng"
 export BUNDLE_GEMFILE="${CC_PACKAGE_DIR}/cloud_controller_ng/Gemfile"
+export STACKS_YML="/var/vcap/jobs/cloud_controller_ng/config/stacks.yml"
 
 function migrate {
     set +e


### PR DESCRIPTION
Signed-off-by: Dave Goddard <dave@goddard.id.au>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Provide an environment variable during database migrations which exposes the location of the `stacks.yml` config file.

* An explanation of the use cases your change solves
A migration which needs to alter data to include the default stack in some situations has no reliable way of identifying the default stack. If, however, the location of the CC's `stacks.yml` file is known, a migration can read it to find out the default stack.

* Links to any other associated PRs
Used to support migration in the following [cloud_controller_ng PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/1064)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
