### PR TITLE
Fixes cloud_controller_ng timeout when starting

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -22,7 +22,7 @@
 
 check process cloud_controller_ng
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid
-  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng" with timeout 60 seconds
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng"
   group vcap
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
I've changed the timeout for starting cloud_controller_ng from the default timeout of 30 seconds to 60 seconds.

* An explanation of the use cases your change solves
This fixes issue described here: https://github.com/cloudfoundry/capi-release/issues/71 

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
