### PR TITLE
Make blobstore better handle many clients

### DIFF
--- a/jobs/blobstore/templates/nginx.conf.erb
+++ b/jobs/blobstore/templates/nginx.conf.erb
@@ -30,9 +30,10 @@ http {
   uwsgi_temp_path /var/vcap/data/blobstore/tmp/uwsgi_temp;
   scgi_temp_path /var/vcap/data/blobstore/tmp/scgi_temp;
 
-  sendfile    on;
-  tcp_nopush  on;
-  tcp_nodelay on;
+  sendfile            on;
+  sendfile_max_chunk  1M;  # Make sure not to block on fast clients reading large files
+  tcp_nopush          on;
+  tcp_nodelay         on;
 
   keepalive_timeout 75 20;
 

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -32,6 +32,7 @@ http {
   access_log  syslog:server=127.0.0.1,severity=info,tag=vcap_nginx_access main;
 
   sendfile             on;  #enable use of sendfile()
+  sendfile_max_chunk   1M;  #make sure not to block on fast clients reading large files
   tcp_nopush           on;
   tcp_nodelay          on;  #disable nagel's algorithm
 


### PR DESCRIPTION
When clients are fast and blobs are big nginx may block on sendfile
which leads to timeouts on rep (hardcoded in cacheddownloader as 10 seconds).

Here is what we see in application events when deploying many cells in parallel:
```
app.crash                 mysuperapp   index: 14, reason: CRASHED, exit_description: Downloading failed
audit.app.process.crash   web          index: 14, reason: CRASHED, exit_description: Downloading failed
```

This change ensures that nginx worker tries to serve other requests after
transferring up to 1M of data to the client.

Notes:
- 1M is arbitrary: not too small to slow transferring down and not too big to block nginx worker