### PR TITLE
Remove unnecessary CA cert file for CC public TLS

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -36,7 +36,6 @@ templates:
   mutual_tls_ca.crt.erb: config/certs/mutual_tls_ca.crt
   public_tls.crt.erb: config/certs/public_tls.crt
   public_tls.key.erb: config/certs/public_tls.key
-  public_tls_ca.crt.erb: config/certs/public_tls_ca.crt
   newrelic.yml.erb: config/newrelic.yml
   newrelic_plugin.yml.erb: config/newrelic_plugin.yml
   nginx.conf.erb: config/nginx.conf

--- a/jobs/cloud_controller_ng/templates/public_tls_ca.crt.erb
+++ b/jobs/cloud_controller_ng/templates/public_tls_ca.crt.erb
@@ -1,3 +1,0 @@
-<% if_p("cc.public_tls.ca_cert") do |ca_cert| %>
-<%= ca_cert %>
-<% end %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Remove unnecessary CA cert file for CC public TLS: The `config/certs/public_tls_ca.crt` file containing the value of the `cc.public_tls.ca_cert` is not used by anything else in the capi-release job templates.

* An explanation of the use cases your change solves

The presence of this unnecessary file is potentially confusing for CF operators and for manifest authors.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
  * Not needed: it is sufficient to deploy CC to BOSH-Lite with the latest cf-deployment and to verify that the gorouter has a TLS backend for it and can route requests to it successfully.
