### PR TITLE
Introduce an option to enable OPI

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -178,3 +178,11 @@ properties:
   cc.locket.port:
     default: 8891
     description: "Port of the Locket server"
+
+  cc.opi.enabled:
+    description: "Enable the amazing eirini component"
+    default: false
+
+  cc.opi.url:
+    description: "Eirini Endpoint"
+    default: ""

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -145,6 +145,10 @@ packages:
   fog_connection: <%= link("cloud_controller_internal").p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.packages.fog_aws_storage_options", {}).to_json %>
 
+opi:
+  url: "<%= p("cc.opi.url") %>"
+  enabled: <%= p("cc.opi.enabled") %>
+
 droplets:
   blobstore_type: <%= link("cloud_controller_internal").p("cc.droplets.blobstore_type") %>
   webdav_config:

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -58,6 +58,13 @@ properties:
   system_domain:
     description: "Domain reserved for CF operator, base URL where the login, uaa, and other non-user apps listen"
 
+  cc.opi.enabled:
+    description: "Enable the amazing eirini component"
+    default: false
+  cc.opi.url:
+    description: "Eirini Endpoint"
+    default: ""
+
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -282,7 +282,7 @@ diego:
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:
-  url: <%= p("cc.opi.url") %>
+  url: "<%= p("cc.opi.url") %>"
   enabled: <%= p("cc.opi.enabled") %>
 
 <% if p("routing_api.enabled") %>

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -281,6 +281,10 @@ diego:
     ca_file: /var/vcap/jobs/cloud_controller_clock/config/certs/mutual_tls_ca.crt
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
+opi:
+  url: <%= p("cc.opi.url") %>
+  enabled: <%= p("cc.opi.enabled") %>
+
 <% if p("routing_api.enabled") %>
 routing_api:
   url: <%= "https://api.#{system_domain}/routing" %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -604,6 +604,14 @@ properties:
     description: "Key pair name for signed download URIs"
     default: ""
 
+  cc.opi.enabled:
+    description: "Enable the amazing eirini component"
+    default: false
+
+  cc.opi.url:
+    description: "Eirini Endpoint"
+    default: ""
+
   ccdb.databases:
     description: "Contains the name of the database on the database server"
   ccdb.roles:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -420,6 +420,10 @@ diego:
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>
 
+opi:
+  url: <%= p("cc.opi.url") %>
+  enabled: <%= p("cc.opi.enabled") %>
+
 perm:
   ca_cert_path: "/var/vcap/jobs/cloud_controller_ng/config/certs/perm_ca.crt"
   timeout_in_milliseconds: <%= p("perm.timeout_in_milliseconds") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -421,7 +421,7 @@ diego:
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>
 
 opi:
-  url: <%= p("cc.opi.url") %>
+  url: "<%= p("cc.opi.url") %>"
   enabled: <%= p("cc.opi.enabled") %>
 
 perm:

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -73,6 +73,13 @@ properties:
   nfs_server.address:
     description: "NFS server for droplets and apps (not used in an AWS deploy, use s3 instead)"
 
+  cc.opi.enabled:
+    description: "Enable the amazing eirini component"
+    default: false
+  cc.opi.url:
+    description: "Eirini Endpoint"
+    default: ""
+
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -258,6 +258,10 @@ diego:
     ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls_ca.crt
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
+opi:
+  url: <%= p("cc.opi.url") %>
+  enabled: <%= p("cc.opi.enabled") %>
+
 <% if p("routing_api.enabled") %>
 routing_api:
   url: <%= "https://api.#{system_domain}/routing" %>

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -259,7 +259,7 @@ diego:
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:
-  url: <%= p("cc.opi.url") %>
+  url: "<%= p("cc.opi.url") %>"
   enabled: <%= p("cc.opi.enabled") %>
 
 <% if p("routing_api.enabled") %>


### PR DESCRIPTION
### A short explanation of the proposed change:
This is a follow up on [Enable pluggable container orchestration using OPI](https://github.com/cloudfoundry/cloud_controller_ng/pull/1205) in the CloudController repo. This PR adds the  properties required to enable the OPI component &mdash; `cc.opi.enabled` and `cc.opi.url` &mdash; in the `cloud_controller_ng` configuration.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite


/cc @julz @andrew-edgar @JulzDiverse @mnitchev @suhlig