### PR TITLE
Add windows stack for lifecycle association

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -152,6 +152,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -500,6 +500,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -987,6 +987,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -514,6 +514,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"


### PR DESCRIPTION
* A short explanation of the proposed change:

Add windows stack for the lifecycle 

* An explanation of the use cases your change solves

This enables `cf push -s windows`

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests
