### PR TITLE
Introduce configurable bbs client timeouts

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -127,6 +127,15 @@ properties:
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889
+  cc.diego.bbs.connect_timeout:
+    description: "Connect timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.send_timeout:
+    description: "Send timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.receive_timeout:
+    description: "Receive timeout when talking to BBS Server"
+    default: 10
 
   cc.mutual_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -78,6 +78,9 @@ diego:
     key_file: /var/vcap/jobs/cc_deployment_updater/config/certs/mutual_tls.key
     cert_file: /var/vcap/jobs/cc_deployment_updater/config/certs/mutual_tls.crt
     ca_file: /var/vcap/jobs/cc_deployment_updater/config/certs/mutual_tls_ca.crt
+    connect_timeout: <%= p("cc.diego.bbs.connect_timeout") %>
+    send_timeout: <%= p("cc.diego.bbs.send_timeout") %>
+    receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -475,6 +475,15 @@ properties:
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889
+    cc.diego.bbs.connect_timeout:
+      description: "Connect timeout when talking to BBS Server"
+      default: 10
+    cc.diego.bbs.send_timeout:
+      description: "Send timeout when talking to BBS Server"
+      default: 10
+    cc.diego.bbs.receive_timeout:
+      description: "Receive timeout when talking to BBS Server"
+      default: 10
 
   cc.mutual_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -279,6 +279,9 @@ diego:
     key_file: /var/vcap/jobs/cloud_controller_clock/config/certs/mutual_tls.key
     cert_file: /var/vcap/jobs/cloud_controller_clock/config/certs/mutual_tls.crt
     ca_file: /var/vcap/jobs/cloud_controller_clock/config/certs/mutual_tls_ca.crt
+    connect_timeout: <%= p("cc.diego.bbs.connect_timeout") %>
+    send_timeout: <%= p("cc.diego.bbs.send_timeout") %>
+    receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -950,6 +950,15 @@ properties:
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889
+  cc.diego.bbs.connect_timeout:
+    description: "Connect timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.send_timeout:
+    description: "Send timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.receive_timeout:
+    description: "Receive timeout when talking to BBS Server"
+    default: 10
 
   cc.mutual_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -422,6 +422,9 @@ diego:
     key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls.key
     cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls.crt
     ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls_ca.crt
+    connect_timeout: <%= p("cc.diego.bbs.connect_timeout") %>
+    send_timeout: <%= p("cc.diego.bbs.send_timeout") %>
+    receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   cc_uploader_url: <%= cc_uploader_url %>
   docker_staging_stack: <%= p("cc.diego.docker_staging_stack") %>
   file_server_url: <%= p("cc.diego.file_server_url") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -489,6 +489,15 @@ properties:
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889
+  cc.diego.bbs.connect_timeout:
+    description: "Connect timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.send_timeout:
+    description: "Send timeout when talking to BBS Server"
+    default: 10
+  cc.diego.bbs.receive_timeout:
+    description: "Receive timeout when talking to BBS Server"
+    default: 10
 
   cc.mutual_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -256,6 +256,9 @@ diego:
     key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls.key
     cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls.crt
     ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls_ca.crt
+    connect_timeout: <%= p("cc.diego.bbs.connect_timeout") %>
+    send_timeout: <%= p("cc.diego.bbs.send_timeout") %>
+    receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:


### PR DESCRIPTION
* A short explanation of the proposed change:
    Make the timeouts used by diego bbs client configurable.

* An explanation of the use cases your change solves:
    We noticed that the hardcoded values of 10s is not enough in environments with more than 100,000 apps. This PR allows a configuration that can be adjusted to the specific environment.
* Links to any other associated PRs
    https://github.com/cloudfoundry/cloud_controller_ng/pull/1257

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
