### PR TITLE
add copilot.temporary_istio_domains property

### DIFF
--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -61,6 +61,7 @@ copilot:
   enabled: <%= link("cloud_controller_internal").p("copilot.enabled") %>
   host: <%= link("cloud_controller_internal").p("copilot.host") %>
   port: <%= copilot_conn.p("listen_port_for_cloud_controller") %>
+  temporary_istio_domains: <%= link("cloud_controller_internal").p("copilot.temporary_istio_domains") %>
   client_ca_file: /var/vcap/jobs/cc_deployment_updater/config/certs/copilot_ca.crt
   client_key_file: /var/vcap/jobs/cc_deployment_updater/config/certs/copilot.key
   client_chain_file: /var/vcap/jobs/cc_deployment_updater/config/certs/copilot.crt

--- a/jobs/cc_route_syncer/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_route_syncer/templates/cloud_controller_ng.yml.erb
@@ -53,6 +53,7 @@ copilot:
   enabled: <%= link("cloud_controller_internal").p("copilot.enabled") %>
   host: <%= link("cloud_controller_internal").p("copilot.host") %>
   port: <%= copilot_conn.p("listen_port_for_cloud_controller") %>
+  temporary_istio_domains: <%= link("cloud_controller_internal").p("copilot.temporary_istio_domains") %>
   client_ca_file: /var/vcap/jobs/cc_route_syncer/config/certs/copilot_ca.crt
   client_key_file: /var/vcap/jobs/cc_route_syncer/config/certs/copilot.key
   client_chain_file: /var/vcap/jobs/cc_route_syncer/config/certs/copilot.crt

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -199,6 +199,7 @@ provides:
   - copilot.client_key_file
   - copilot.enabled
   - copilot.host
+  - copilot.temporary_istio_domains
   - credhub_api.ca_cert
   - credhub_api.hostname
   - release_level_backup
@@ -1058,6 +1059,14 @@ properties:
     description: "Controls whether CredHub credentials are automatically interpolated in VCAP_SERVICES"
     default: true
 
+  cc.internal_route_vip_range:
+    default: "127.128.0.0/9"
+    description: "The ipv4 CIDR range of virtual IP addresses to be assigned to routes on internal domains.
+                  WARNING: Changing this range is not supported, and has undefined behaviors.
+                  It is recommended to leave this value as the default.
+                  If this range is changed, it is likely the routes on the internal service mesh domain
+                  will need to be recreated."
+
   copilot.enabled:
     description: "Enable communication with CF Copilot. Must be enabled when using Envoy for ingress routing."
     default: false
@@ -1070,11 +1079,6 @@ properties:
     description: "PEM-encoded Client key for communication with CF Copilot"
   copilot.client_chain_file:
     description: "PEM-encoded Client cert chain for communication with CF Copilot"
-
-  cc.internal_route_vip_range:
-    default: "127.128.0.0/9"
-    description: "The ipv4 CIDR range of virtual IP addresses to be assigned to routes on internal domains.
-                  WARNING: Changing this range is not supported, and has undefined behaviors.
-                  It is recommended to leave this value as the default.
-                  If this range is changed, it is likely the routes on the internal service mesh domain
-                  will need to be recreated."
+  copilot.temporary_istio_domains:
+    description: "Array of domains (strings) to be used for routes propagated to the Envoy/Istio routing tier. These routes will not be propagated to Gorouter."
+    default: []

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -447,6 +447,7 @@ copilot:
   enabled: <%= p("copilot.enabled") %>
   host: <%= p("copilot.host") %>
   port: <%= copilot_conn.p("listen_port_for_cloud_controller") %>
+  temporary_istio_domains: <%= p("copilot.temporary_istio_domains") %>
   client_ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/copilot_ca.crt
   client_key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/copilot.key
   client_chain_file: /var/vcap/jobs/cloud_controller_ng/config/certs/copilot.crt

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -287,6 +287,7 @@ copilot:
   enabled: <%= link("cloud_controller_internal").p("copilot.enabled") %>
   host: <%= link("cloud_controller_internal").p("copilot.host") %>
   port: <%= copilot_conn.p("listen_port_for_cloud_controller") %>
+  temporary_istio_domains: <%= link("cloud_controller_internal").p("copilot.temporary_istio_domains") %>
   client_ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/copilot_ca.crt
   client_key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/copilot.key
   client_chain_file: /var/vcap/jobs/cloud_controller_worker/config/certs/copilot.crt


### PR DESCRIPTION

* A short explanation of the proposed change:

Operators can add a list of istio domains to the `copilot.temporary_istio_domains` property in the manifest. Cloud Controller then filters routes sent to Copilot based on whether they're associated with an Istio domain.

* An explanation of the use cases your change solves
[Tracker Story](https://www.pivotaltracker.com/story/show/159944349)

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1263

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
