### PR TITLE
Add property to allow opting into enabling declarative asset downloads

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -169,6 +169,9 @@ properties:
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~
+  cc.diego.enable_declarative_asset_downloads:
+    description: "Enable specifying task and app asset downloads as declarative resources"
+    default: false
   cc.diego.pid_limit:
     description: "Maximum pid limit for containerized work running user-provided code"
     default: 1024

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -68,6 +68,7 @@ copilot:
 
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
+  enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
   file_server_url: <%= p("cc.diego.file_server_url") %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -521,6 +521,9 @@ properties:
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~
+  cc.diego.enable_declarative_asset_downloads:
+    description: "Enable specifying task and app asset downloads as declarative resources"
+    default: false
   cc.diego.pid_limit:
     description: "Maximum pid limit for containerized work running user-provided code"
     default: 1024

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -270,6 +270,7 @@ skip_cert_verify: <%= p("ssl.skip_cert_verify") %>
 
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
+  enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
   file_server_url: <%= p("cc.diego.file_server_url") %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1019,6 +1019,9 @@ properties:
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~
+  cc.diego.enable_declarative_asset_downloads:
+    description: "Enable specifying task and app asset downloads as declarative resources"
+    default: false
   cc.diego.pid_limit:
     description: "Maximum pid limit for containerized work running user-provided code"
     default: 1024

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -432,6 +432,7 @@ diego:
   lifecycle_bundles: <%= p("cc.diego.lifecycle_bundles").to_json %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
+  enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -531,6 +531,9 @@ properties:
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~
+  cc.diego.enable_declarative_asset_downloads:
+    description: "Enable specifying task and app asset downloads as declarative resources"
+    default: false
   cc.diego.pid_limit:
     description: "Maximum pid limit for containerized work running user-provided code"
     default: 1024

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -246,6 +246,7 @@ bits_service:
 
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
+  enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
   file_server_url: <%= p("cc.diego.file_server_url") %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>


### PR DESCRIPTION
* A short explanation of the proposed change:

  Add a new configuration option to allow operators to configure CC to generate LRPs and Tasks that utilize the new declarative format of specifying assets to download and make available in containers. This change will allow Diego and Garden to be more flexible about opting in to turning these assets into container image layers for improved performance and consolidated caching.

* Links to any other associated PRs:
  - Relies on bumping the `bbs` to [this commit](https://github.com/cloudfoundry/bbs/commit/241fb8364c287973b19af9c60a27364d82b1371b)
  - `cloud_controller_ng` PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/1266

* Links to any other associated stories:
  - https://www.pivotaltracker.com/story/show/158950019

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
