### PR TITLE
expose internal_route_vip_range as link

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -103,6 +103,10 @@ provides:
   - cc.internal_service_hostname
   - cc.tls_port
   - cc.mutual_tls.ca_cert
+- name: cloud_controller_networking_info
+  type: cloud_controller_networking_info
+  properties:
+  - cc.internal_route_vip_range
 - name: cloud_controller_internal
   type: cloud_controller_internal
   properties:


### PR DESCRIPTION
[#162515686]

Signed-off-by: Alex Standke <astandke@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Expose `internal_route_vip_range` as bosh link

* An explanation of the use cases your change solves

We wanna use it so it's only configured in one place (and not hardcoded 😐)

* Links to any other associated PRs

Nada

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* ~~I have run CF Acceptance Tests on bosh lite~~
