### PR TITLE
Configure tps-watcher to log human-readable RFC3339 timestamps

### DIFF
--- a/jobs/tps/templates/tps_watcher_config.json.erb
+++ b/jobs/tps/templates/tps_watcher_config.json.erb
@@ -22,7 +22,7 @@ config[:cc_ca_cert] = "#{conf_dir}/certs/cc/ca.crt"
 config[:consul_cluster] =  "http://127.0.0.1:" + p("capi.tps.consul_agent_port").to_s
 config[:debug_server_config] = { debug_address: p("capi.tps.watcher.debug_addr") }
 config[:dropsonde_port] =  p("capi.tps.dropsonde_port")
-config[:lager_config] = { log_level: p("capi.tps.log_level") }
+config[:lager_config] = { log_level: p("capi.tps.log_level"), time_format: "rfc3339" }
 
 if p("capi.tps.bbs.require_ssl")
   config[:locket_client_cert_file] = "#{conf_dir}/certs/bbs/client.crt"


### PR DESCRIPTION
This change configures the tps-watcher component to format the timestamps in its logs in RFC3339 format, which is more human-readable than the current Unix epoch timestamp while still being straightforward for machines to process.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
  - Not applicable to this change, as it does not affect component functionality
