### PR TITLE
Add properties for key rotation errand logging

### DIFF
--- a/jobs/rotate_cc_database_key/spec
+++ b/jobs/rotate_cc_database_key/spec
@@ -30,3 +30,10 @@ properties:
   bpm.enabled:
     description: "Enable Bosh Process Manager"
     default: true
+
+  cc.logging_level:
+    description: "If provided, overrides cc.logging_level from cloud_controller_internal link"
+  cc.log_db_queries:
+    description: "If provided, overrides cc.log_db_queries from cloud_controller_internal link"
+  cc.db_logging_level:
+    description: "If provided, overrides cc.db_logging_level from cloud_controller_internal link"

--- a/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
+++ b/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
@@ -22,7 +22,7 @@ default_app_ssh_access: <%= link("cloud_controller_internal").p("cc.default_app_
 logging:
   file: /var/vcap/sys/log/rotate_cc_database_key/rotate_cc_database_key.log
   syslog: vcap.cloud_controller_ng
-  level: "<%= link("cloud_controller_internal").p("cc.logging_level") %>"
+  level: "<%= p("cc.logging_level", link("cloud_controller_internal").p("cc.logging_level")) %>"
   max_retries: <%= link("cloud_controller_internal").p("cc.logging_max_retries") %>
 
 <% db = link("cloud_controller_db").p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
@@ -46,8 +46,8 @@ db: &db
     database: <%= db["name"] %>
   max_connections: <%= link("cloud_controller_db").p("ccdb.max_connections") %>
   pool_timeout: <%= link("cloud_controller_db").p("ccdb.pool_timeout") %>
-  log_level: "<%= link("cloud_controller_internal").p("cc.db_logging_level") %>"
-  log_db_queries: <%= link("cloud_controller_internal").p("cc.log_db_queries") %>
+  log_level: "<%= p("cc.db_logging_level", link("cloud_controller_internal").p("cc.db_logging_level")) %>"
+  log_db_queries: <%= p("cc.log_db_queries", link("cloud_controller_internal").p("cc.log_db_queries")) %>
   ssl_verify_hostname: <%= link("cloud_controller_db").p("ccdb.ssl_verify_hostname") %>
   read_timeout: <%= link("cloud_controller_db").p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= link("cloud_controller_db").p("ccdb.connection_validation_timeout") %>


### PR DESCRIPTION
As outlined in #114 we have logging enabled for cc and this causes the rotate key errand to fail on bigger landscapes with too many log messages. Thus we want to set the log level for the errand specifically. We do not change the previous behavior, i.e. if not provided the cc log level will be used. The added properties are optional.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
  * Not applicable to this change, as it does not affect component functionality
  * We created a dev release and tested the errand with different logging levels
