### PR TITLE
Fix chpst permissions issue

### DIFF
--- a/jobs/cloud_controller_clock/templates/pre-start.sh.erb
+++ b/jobs/cloud_controller_clock/templates/pre-start.sh.erb
@@ -2,6 +2,9 @@
 
 set -ex
 
+mkdir -p "/var/vcap/data/cloud_controller_clock/tmp"
+chown vcap:vcap "/var/vcap/data/cloud_controller_clock/tmp"
+
 BUNDLER_DIR=/var/vcap/data/cloud_controller_clock/tmp/bundler
 chpst -u vcap:vcap mkdir -p $BUNDLER_DIR
 chpst -u vcap:vcap chmod -R go-w $BUNDLER_DIR

--- a/jobs/cloud_controller_worker/templates/pre-start.sh.erb
+++ b/jobs/cloud_controller_worker/templates/pre-start.sh.erb
@@ -18,6 +18,9 @@ function setup_directories {
   mkdir -p "/var/vcap/sys/log/cloud_controller_worker"
   chown -R vcap:vcap "/var/vcap/sys/log/cloud_controller_worker"
 
+  mkdir -p "/var/vcap/data/cloud_controller_worker/tmp"
+  chown vcap:vcap "/var/vcap/data/cloud_controller_worker/tmp"
+
   BUNDLER_DIR=/var/vcap/data/cloud_controller_worker/tmp/bundler
   chpst -u vcap:vcap mkdir -p $BUNDLER_DIR
   chpst -u vcap:vcap chmod -R go-w $BUNDLER_DIR


### PR DESCRIPTION
The issue occurs when trying to deploy capi-release with the current latest (2.14.5) version of Containerized CF (SCF). We are constantly getting  errors for the worker and clock components.

With a bit of help from @jandubois and @viovanov we saw that the two lines

```
mkdir -p "/var/vcap/data/<job_name>/tmp"
chown vcap:vcap "/var/vcap/data/<job_name>/tmp"
```
were present for `cloud_controller_ng` job, but missing for `cloud_controller_clock` and `cloud_controller_worker`. After adding them, the components were started without a problem. 

Thanks,
Georgi & @JulzDiverse

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
