### PR TITLE
Accept an array of app domains as an entry to the app_domains template property in cloud_controller_ng

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -61,7 +61,7 @@ temporary_use_logcache: <%= p("cc.temporary_use_logcache") %>
 system_domain_organization: <%= p("system_domain_organization") %>
 system_domain: <%= p("system_domain") %>
 app_domains: <%=
-  app_domains = p("app_domains")
+  app_domains = p("app_domains").flatten
   validate_app_domains(app_domains)
   app_domains.to_json
 %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -164,6 +164,29 @@ module Bosh::Template::Test
             end.to raise_error(StandardError, 'Error for app_domains: Router groups cannot be specified for internal domains.')
           end
         end
+
+        context 'when an entry is an array of domains' do
+          before do
+            merged_manifest_properties['app_domains'] = [
+              'brook-sentry.capi.land',
+              { 'internal' => true, 'name' => 'foo.brook-sentry.capi.land' },
+              [
+                { 'internal' => true, 'name' => 'bar.some.internal' },
+                'baz.capi.land'
+              ]
+            ]
+          end
+
+          it 'flattens the array of domains' do
+            template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            expect(template_hash['app_domains']).to eq([
+              'brook-sentry.capi.land',
+              { 'internal' => true, 'name' => 'foo.brook-sentry.capi.land' },
+              { 'internal' => true, 'name' => 'bar.some.internal' },
+              'baz.capi.land'
+            ])
+          end
+        end
       end
 
       describe 'internal route vip range' do


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This change is to accept an array of domains as an entry to `app_domains` in cloud_controller_ng to support populating the spec property from two different form fields.

* An explanation of the use cases your change solves

n/a

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [n/a] I have run CF Acceptance Tests on bosh lite
