### PR TITLE
Introduce optional staging on OPI

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -68,6 +68,9 @@ properties:
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""
+  cc.opi.cc_uploader_url:
+    description: "URL of cc uploader"
+    default: http://cc-uploader.service.cf.internal:9090
 
   cc.external_port:
     description: "External Cloud Controller port"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -62,6 +62,9 @@ properties:
   cc.opi.enabled:
     description: "Enable the amazing eirini component"
     default: false
+  cc.opi.opi_staging:
+    description: "Enable the amazing eirini staging"
+    default: false
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -290,6 +290,7 @@ diego:
 
 opi:
   url: "<%= p("cc.opi.url") %>"
+  opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
 
 <% if p("routing_api.enabled") %>

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -292,6 +292,7 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
+  cc_uploader_url: "<%= p("cc.opi.cc_uploader_url") %>"
 
 <% if p("routing_api.enabled") %>
 routing_api:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -619,6 +619,9 @@ properties:
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""
+  cc.opi.cc_uploader_url:
+    description: "URL of cc uploader"
+    default: http://cc-uploader.service.cf.internal:9090
 
   ccdb.databases:
     description: "Contains the name of the database on the database server"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -613,7 +613,9 @@ properties:
   cc.opi.enabled:
     description: "Enable the amazing eirini component"
     default: false
-
+  cc.opi.opi_staging:
+    description: "Enable the amazing eirini staging"
+    default: false
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -439,6 +439,7 @@ diego:
 
 opi:
   url: "<%= p("cc.opi.url") %>"
+  opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
 
 perm:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -441,6 +441,7 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
+  cc_uploader_url: "<%= p("cc.opi.cc_uploader_url") %>"
 
 perm:
   enabled: false

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -77,6 +77,9 @@ properties:
   cc.opi.enabled:
     description: "Enable the amazing eirini component"
     default: false
+  cc.opi.opi_staging:
+    description: "Enable the amazing eirini staging"
+    default: false
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -83,6 +83,9 @@ properties:
   cc.opi.url:
     description: "Eirini Endpoint"
     default: ""
+  cc.opi.cc_uploader_url:
+    description: "URL of cc uploader"
+    default: http://cc-uploader.service.cf.internal:9090
 
   cc.external_port:
     description: "External Cloud Controller port"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -265,6 +265,7 @@ diego:
 
 opi:
   url: "<%= p("cc.opi.url") %>"
+  opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
 
 <% if p("routing_api.enabled") %>

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -267,6 +267,7 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
+  cc_uploader_url: "<%= p("cc.opi.cc_uploader_url") %>"
 
 <% if p("routing_api.enabled") %>
 routing_api:


### PR DESCRIPTION
This is a follow up on [Enable OPI staging](https://github.com/cloudfoundry/cloud_controller_ng/pull/1288) in the CloudController repo. This PR adds the properties required to enable staging using the OPI component — `cc.opi.opi_staging` and `cc.opi.cc_uploader_url` — in the cloud_controller_ng configuration.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
We deploy Eirini using Kubernetes (instead of Diego) and run CATs apps suite on a regular basis in our [pipeline](https://ci.flintstone.cf.cloud.ibm.com/teams/eirini/pipelines/acceptance/jobs/run-core-cats/builds/12). 

cc @suhlig @julz @JulzDiverse @mnitchev