### PR TITLE
Don't complete post-start until healthcheck completes successfully

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -323,6 +323,10 @@ properties:
     default: "api"
     description: "Host part of the cloud_controller api URI, will be joined with value of 'domain'"
 
+  cc.api_post_start_healthcheck_timeout_in_seconds:
+    default: 60
+    description: "Maximum time (in seconds) for cloud_controller_ng to report healthy"
+
   cc.api_health_check_timeout_per_retry:
     default: 2
     description: "Maximum health check timeout (in seconds) for each retry attempt in the Cloud Controller's route registration health check"

--- a/jobs/cloud_controller_ng/templates/post-start.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-start.sh.erb
@@ -12,6 +12,8 @@ export BUNDLE_GEMFILE="${CC_PACKAGE_DIR}/cloud_controller_ng/Gemfile"
 
 source "${CC_JOB_DIR}/bin/ruby_version.sh"
 source /var/vcap/packages/capi_utils/syslog_utils.sh
+source /var/vcap/packages/capi_utils/monit_utils.sh
+
 tee_output_to_sys_log "cloud_controller_ng.$(basename "$0")"
 
 function fix_bundler_home_permissions {
@@ -44,5 +46,7 @@ function main {
 }
 
 main
+
+wait_for_server_to_become_healthy "http://localhost:<%= p("cc.external_port") %>/v2/info" "<%= p("cc.api_post_start_healthcheck_timeout_in_seconds") %>"
 
 exit 0


### PR DESCRIPTION
This is to prevent a `cloud_controller_ng` that fails to start properly from incorrectly passing canary tests.

* A short explanation of the proposed change:

Don't complete `post-start` for `cloud_controller_ng` until the same healthcheck that `monit` uses passes.

* An explanation of the use cases your change solves

Prior to this change if `cloud_controller_ng` took too long to start, `monit` would force it into a crash loop, however `bosh` would not detect the failure and thus would promote the canary to all `api` servers, eventually taking out an entire CloudFoundry installation.

See full write-up in: https://github.com/cloudfoundry/capi-release/issues/125

This PR attempts fix the `bosh` deployment so that it will correctly fail to pass the canary if `cloud_controller_ng` fails to start successfully.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [no] I have run CF Acceptance Tests on bosh lite

But I have deployed a patched bosh release to a running CloudFoundry and it didn't break.

I then patched the release again to open a socket on the wrong path, and verified that the `post-start` script did fail.

```
Task 509330 | 07:03:41 | Updating instance api: api/67d7a896-d497-4180-b9b3-eeab4d11491f (0) (canary) (00:02:32)
                      L Error: Action Failed get_task: Task 997ffd0d-077e-43fa-5d31-1f1adce04bf4 result: 1 of 4 post-start scripts failed. Failed Jobs: cloud_controller_ng. Successful Jobs: policy-server, policy-server-internal, bosh-dns.
Task 509330 | 07:06:13 | Error: Action Failed get_task: Task 997ffd0d-077e-43fa-5d31-1f1adce04bf4 result: 1 of 4 post-start scripts failed. Failed Jobs: cloud_controller_ng. Successful Jobs: policy-server, policy-server-internal, bosh-dns.
```

