### PR TITLE
Add v2 logging endpoint to CAPI root

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -148,6 +148,9 @@ loggregator:
   router: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
   internal_url: <%= p("cc.loggregator.internal_url") %>
 
+log_stream:
+  url: https://log-stream.<%= p("system_domain") %>
+
 doppler:
   url: ws<%= "s" if p("doppler.use_ssl") %>://doppler.<%= p("system_domain") %>:<%= p("doppler.port") %>
 


### PR DESCRIPTION
[#164094017]

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

This adds the v2 logging endpoint to the CAPI root. We've announced deprecation of the v1 API and this change will make the v2 api more discoverable.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1301


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
