### PR TITLE
Introduce optional bosh link active_signing_key

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -51,6 +51,9 @@ consumes:
   optional: true
 - name: cloud_controller_internal
   type: cloud_controller_internal
+- name: bits_service_active_signing_key
+  type: bits_service_active_signing_key
+  optional: true
 
 properties:
   bpm.enabled:

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -204,6 +204,10 @@ bits_service:
   private_endpoint: <%= link("cloud_controller_internal").p("cc.bits_service.private_endpoint") %>
   username: <%= link("cloud_controller_internal").p("cc.bits_service.username") %>
   password: <%= yaml_escape(link("cloud_controller_internal").p("cc.bits_service.password")) %>
+  <% if_link("bits_service_active_signing_key") do |active_signing_key| %>
+  signing_key_id: <%= active_signing_key.p("bits-service.active_signing_key.key_id") %>
+  signing_key_secret: <%= active_signing_key.p("bits-service.active_signing_key.secret") %>
+  <% end %>
 
 skip_cert_verify: <%= link("cloud_controller_internal").p("ssl.skip_cert_verify") %>
 

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -46,6 +46,9 @@ consumes:
 - name: cloud_controller_internal
   type: cloud_controller_internal
   optional: true
+- name: bits_service_active_signing_key
+  type: bits_service_active_signing_key
+  optional: true
 
 properties:
   bpm.enabled:

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -158,6 +158,10 @@ bits_service:
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
   username: <%= p("cc.bits_service.username") %>
   password: <%= yaml_escape(p("cc.bits_service.password")) %>
+  <% if_link("bits_service_active_signing_key") do |active_signing_key| %>
+  signing_key_id: <%= active_signing_key.p("bits-service.active_signing_key.key_id") %>
+  signing_key_secret: <%= active_signing_key.p("bits-service.active_signing_key.secret") %>
+  <% end %>
 
 resource_pool:
   blobstore_type: <%= p("cc.resource_pool.blobstore_type") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -234,6 +234,9 @@ consumes:
 - name: log-cache
   type: log-cache
   optional: true
+- name: bits_service_active_signing_key
+  type: bits_service_active_signing_key
+  optional: true
 
 properties:
   bpm.enabled:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -401,6 +401,10 @@ bits_service:
   <% if p("cc.bits_service.ca_cert") != "" && p("cc.bits_service.ca_cert") != nil %>
   ca_cert_path: /var/vcap/jobs/cloud_controller_ng/config/certs/bits_service_ca.crt
   <% end %>
+  <% if_link("bits_service_active_signing_key") do |active_signing_key| %>
+  signing_key_id: <%= active_signing_key.p("bits-service.active_signing_key.key_id") %>
+  signing_key_secret: <%= active_signing_key.p("bits-service.active_signing_key.secret") %>
+  <% end %>
 
 rate_limiter:
   enabled: <%= p("cc.rate_limiter.enabled") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -58,6 +58,9 @@ consumes:
 - name: cloud_controller_internal
   type: cloud_controller_internal
   optional: true
+- name: bits_service_active_signing_key
+  type: bits_service_active_signing_key
+  optional: true
 
 properties:
   bpm.enabled:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -244,6 +244,10 @@ bits_service:
   <% if p("cc.bits_service.ca_cert") != "" && p("cc.bits_service.ca_cert") != nil %>
   ca_cert_path: /var/vcap/jobs/cloud_controller_worker/config/certs/bits_service_ca.crt
   <% end %>
+  <% if_link("bits_service_active_signing_key") do |active_signing_key| %>
+  signing_key_id: <%= active_signing_key.p("bits-service.active_signing_key.key_id") %>
+  signing_key_secret: <%= active_signing_key.p("bits-service.active_signing_key.secret") %>
+  <% end %>
 
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>


### PR DESCRIPTION
* A short explanation of the proposed change:

    Consume Bits-Service bosh-links for a shared secret.

* An explanation of the use cases your change solves

    Bits-Service provides bosh-links for a shared secret to create signed Bits-Service URLs. By consuming them Cloud Controller can now create signed URLs. This change does not change any behavior of Cloud Controller, but it is a pre-requisite for https://github.com/cloudfoundry/cloud_controller_ng/pull/1305.


* Links to any other associated PRs

    This PR is a pre-requisite for https://github.com/cloudfoundry/cloud_controller_ng/pull/1305

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
