### PR TITLE
Ensure that cc ng waits until provided timeout to populate routes

### DIFF
--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -8,7 +8,7 @@ source /var/vcap/packages/capi_utils/monit_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 60
+  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180
 
   rm /var/vcap/data/cloud_controller_ng/tmp/proxy_temp/bbr_maintenance
 

--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -8,7 +8,7 @@ source /var/vcap/packages/capi_utils/monit_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180
+  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180 10
 
   rm /var/vcap/data/cloud_controller_ng/tmp/proxy_temp/bbr_maintenance
 

--- a/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
@@ -8,7 +8,7 @@ source /var/vcap/packages/capi_utils/monit_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180
+  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180 10
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
   monit_start_job cloud_controller_worker_local_<%= index %>

--- a/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
@@ -8,7 +8,7 @@ source /var/vcap/packages/capi_utils/monit_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 60
+  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 180
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
   monit_start_job cloud_controller_worker_local_<%= index %>

--- a/src/capi_utils/monit_utils.sh
+++ b/src/capi_utils/monit_utils.sh
@@ -38,7 +38,7 @@ function wait_for_server_to_become_unavailable() {
 function wait_for_server_to_become_healthy() {
   local url=$1
   local timeout=${2:-180}
-  local threshold=${3:-10}
+  local threshold=${3:-1}
   local consecutive_success_count=0
 
   for _ in $(seq "${timeout}"); do


### PR DESCRIPTION
Improve DRATs reliability by improving CAPI availability in BBR scripts

Make script require more robust success responses before declaring
server to be "healthy". The number of successes and the timeout are
configurable. 

Signed-off-by: Elena Sharma <esharma@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

With this change, the unlock scripts for CC ng job will more reliably signal that CC is back up. 

* An explanation of the use cases your change solves

As a result of this change the subsequent BBR jobs will not hit a 404/502 error when trying to target CC API endpoint.

* Links to any other associated PRs

A similar change had to be committed to UAA:
https://github.com/cloudfoundry/uaa-release/pull/104

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [-] I have run CF Acceptance Tests on bosh lite
CATs don't cover this functionality, instead we:
- built the release and deployed it against a deployment
- run a set of DRATs and watched it succeed.