### PR TITLE
Ensure that cc ng waits to populate routes - second try

### DIFF
--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -11,7 +11,8 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 60
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
+  sleep 30
 
   rm /var/vcap/data/cloud_controller_ng/tmp/proxy_temp/bbr_maintenance
 

--- a/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
@@ -11,7 +11,8 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   wait_for_server_to_become_unavailable <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/" %> 60
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/v2/info" %> 60
+  sleep 30
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
   monit_start_job cloud_controller_worker_local_<%= index %>


### PR DESCRIPTION
Improve PDRATs reliability by improving the way autoscaling, usage-service and notifications block on CAPI availability in their BBR scripts

Signed-off-by: Slawek Ligus <sligus@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

With this change, the unlock scripts for CC ng job will wait (60 seconds) until CC is probably back up.

This is similar to our previous PR, #131, but in this PR we sleep instead of attempting to check if CC is back up. This skips [all the weirdness around maintenance mode](https://github.com/cloudfoundry/capi-release/pull/131#issuecomment-473443428).

* An explanation of the use cases your change solves

As a result of this change the subsequent BBR jobs will not hit a 404/502 error when trying to target CC API endpoint.

* Links to any other associated PRs

This is an updated version of #131.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] ~~I have run CF Acceptance Tests on bosh lite~~ - we have not done this because CATS does not cover this use case. We have run DRATS on a deployment of PAS 2.4 (HA) and SRT 2.4 (single CC VM) on GCP.


cc @oozie @pivotaljohn / @mcwumbly