### PR TITLE
Do not maintain cc_uploader_https_url property for OPI

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -628,9 +628,6 @@ properties:
   cc.opi.url:
     description: "URL of the Eirini server"
     default: ""
-  cc.opi.cc_uploader_https_url:
-    description: "URL of cc uploader (not used if BOSH link 'cc_uploader' is present)"
-    default: https://cc-uploader.service.cf.internal:9091
 
   ccdb.databases:
     description: "Contains the name of the database on the database server"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -413,13 +413,10 @@ rate_limiter:
 
 <%
 cc_uploader_url = nil
-opi_cc_uploader_url = nil
 if_link("cc_uploader") do |cc_uploader|
   cc_uploader_url = "https://#{cc_uploader.p("internal_hostname")}:#{cc_uploader.p("https_port")}"
-  opi_cc_uploader_url = cc_uploader_url.dup
 end.else do
   cc_uploader_url = p("cc.diego.cc_uploader_https_url")
-  opi_cc_uploader_url = p("cc.opi.cc_uploader_https_url")
 end
 %>
 
@@ -448,7 +445,7 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
-  cc_uploader_url: "<%= opi_cc_uploader_url %>"
+  cc_uploader_url: "<%= cc_uploader_url %>"
 
 perm:
   enabled: false


### PR DESCRIPTION
The property will always come from a BOSH link and it's going to be the same for both OPI and Diego, so there's no need for this duplication.

Follow-up on [this](https://cloudfoundry.slack.com/archives/C8RU3BZ26/p1552424192298600) discussion.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
