### PR TITLE
Add configuration for CC thin thread pool size

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1136,6 +1136,6 @@ properties:
     description: "Array of domains (strings) to be used for routes propagated to the Envoy/Istio routing tier. These routes will not be propagated to Gorouter."
     default: []
 
-  cc.experimental.thread_count:
-    description: "How many threads a single cloud controller instance will attempt to use. Alter at your own peril."
-    default: 20
+  cc.experimental.thin_server.thread_pool_size:
+    description: "How many threads a single cloud controller instance's thin server will attempt to use. Alter at your own peril."
+    default: 20 # inherited from default in Thin/EventMachine

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1135,3 +1135,7 @@ properties:
   copilot.temporary_istio_domains:
     description: "Array of domains (strings) to be used for routes propagated to the Envoy/Istio routing tier. These routes will not be propagated to Gorouter."
     default: []
+
+  cc.experimental.thread_count:
+    description: "How many threads a single cloud controller instance will attempt to use. Alter at your own peril."
+    default: 20

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -471,4 +471,4 @@ max_annotations_per_resource: <%= p("cc.max_annotations_per_resource") %>
 
 internal_route_vip_range: <%= internal_vip_range %>
 
-threadpool_size: <%= p("cc.experimental.thread_count") %>
+threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -470,3 +470,5 @@ max_annotations_per_resource: <%= p("cc.max_annotations_per_resource") %>
 %>
 
 internal_route_vip_range: <%= internal_vip_range %>
+
+threadpool_size: <%= p("cc.experimental.thread_count") %>


### PR DESCRIPTION
Related CC PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/1356

Increase to give CC a softer, smoother texture.

Here is an example ops file to use with this:
```yml
---
- type: replace
  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/experimental?/thread_count?
  value: 21
```