### PR TITLE
Add params to provide OPI client certificate

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -45,6 +45,9 @@ templates:
   nginx_maintenance.conf.erb: config/nginx_maintenance.conf
   nginx_ctl.erb: bin/nginx_ctl
   nginx_newrelic_plugin_ctl.erb: bin/nginx_newrelic_plugin_ctl
+  opi_tls.crt.erb: config/certs/opi_tls.crt
+  opi_tls.key.erb: config/certs/opi_tls.key
+  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
   packages_ca_cert.pem.erb: config/certs/packages_ca_cert.pem
   perform_blobstore_benchmarks.erb: bin/perform_blobstore_benchmarks
   post-start.sh.erb: bin/post-start
@@ -634,6 +637,12 @@ properties:
   cc.opi.url:
     description: "URL of the Eirini server"
     default: ""
+  cc.opi.client_cert:
+    description: "Client certificate for connecting to the OPI server"
+  cc.opi.client_key:
+    description: "Client key for connecting to the OPI server"
+  cc.opi.ca_cert:
+    description: "The ca cert of the OPI server"
 
   ccdb.databases:
     description: "Contains the name of the database on the database server"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -439,7 +439,11 @@ opi:
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
   cc_uploader_url: "<%= cc_uploader_url %>"
-
+<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
+  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls_ca.crt
+  client_cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls.crt
+  client_key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls.key
+<% end %>
 perm:
   enabled: false
 

--- a/jobs/cloud_controller_ng/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_cert") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_ng/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls.key.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_key") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_ng/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls_ca.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.ca_cert") do |certificate| %>
+<%= certificate %>
+<% end %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add OPI client certificate keys

* An explanation of the use cases your change solves
Allow mTLS support between Cloud Controller and Eirini OPI

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1357
p.s. Cloud Controller Submodule needs to be bumped.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite

@jpalermo && @madamkiwi