### PR TITLE
add internal_route_vip_range to cc route syncer job

### DIFF
--- a/jobs/cc_route_syncer/spec
+++ b/jobs/cc_route_syncer/spec
@@ -35,6 +35,8 @@ consumes:
   optional: true
 - name: cloud_controller_internal
   type: cloud_controller_internal
+- name: cloud_controller_container_networking_info
+  type: cloud_controller_container_networking_info
 
 properties:
   ccdb.databases:
@@ -100,6 +102,8 @@ properties:
   cc.thresholds.api.restart_if_above_mb:
     description: "The cc will restart if memory remains above this threshold for 3 monit cycles"
     default: 3750
+  cc.internal_route_vip_range:
+    description: "The ipv4 CIDR range of virtual IP addresses to be assigned to routes on internal domains."
 
   copilot.sync_frequency_in_seconds:
     description: "How often to synchronize CC routes with Copilot"

--- a/jobs/cc_route_syncer/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_route_syncer/templates/cloud_controller_ng.yml.erb
@@ -62,6 +62,18 @@ database_encryption:
   pbkdf2_hmac_iterations: <%= link("cloud_controller_internal").p("cc.database_encryption.experimental_pbkdf2_hmac_iterations") %>
 <% end %>
 
+<% if_link("cloud_controller_container_networking_info") do |info|
+  internal_vip_range = "#{info.p("cc.internal_route_vip_range")}"
+  raise StandardError.new("invalid cc.internal_route_vip_range: #{internal_vip_range}") unless internal_vip_range =~ /\A (?:\d{1,3}\.){3} \d{1,3} \/ \d{1,3} \z/x
+
+  parts = internal_vip_range.split(/[\.\/]/).map(&:to_i)
+  raise StandardError.new("invalid cc.internal_route_vip_range: #{internal_vip_range}") if parts[0..3].any? {|x| x > 255} || parts[4] > 32
+%>
+internal_route_vip_range: <%= internal_vip_range %>
+<% end %>
+
+
+
 <% if_link("cloud_controller_to_copilot_conn") do |copilot_conn| %>
 copilot:
   enabled: <%= link("cloud_controller_internal").p("copilot.enabled") %>

--- a/spec/cc_route_syncer/cloud_controller_ng_spec.rb
+++ b/spec/cc_route_syncer/cloud_controller_ng_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+module Bosh::Template::Test
+  describe 'cloud_controller_ng job template rendering' do
+    let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+    let(:release) { ReleaseDir.new(release_path) }
+    let(:job) { release.job('cc_route_syncer') }
+    let(:merged_manifest_properties) do
+      {
+        'ccdb' =>
+          { 'databases' => [ {'tag' => 'cc' }],
+            'port' => 3306,
+            'roles' =>
+              [{ 'password' => '((the_sanitized_password))',
+                 'tag' => 'admin' }] },
+      }
+    end
+    let(:db_link) do
+      Link.new(name: 'database',
+               instances: [LinkInstance.new(address: 'some-database-address')])
+    end
+
+    let(:internal_properties) do
+      {
+        'cc' =>
+          {'database_encryption' =>
+           {'experimental_pbkdf2_hmac_iterations' => 'wow'}
+          }
+      }
+    end
+    let(:internal_link) do
+      Link.new(name: 'cloud_controller_internal',
+               properties: internal_properties)
+    end
+    let(:cc_networking_link) do
+      Link.new(name: 'cloud_controller_container_networking_info',
+               properties: {'cc' => {'internal_route_vip_range' => '127.128.0.0/9'}})
+    end
+
+    let(:links) { [db_link, internal_link, cc_networking_link] }
+
+    describe 'config/cloud_controller_ng.yml' do
+      let(:template) { job.template('config/cloud_controller_ng.yml') }
+
+      it 'creates the cloud_controller_ng.yml config file' do
+        expect do
+          YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+        end.to_not raise_error
+      end
+
+      describe 'internal route vip range' do
+        it 'has a default range' do
+          rendered_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+          expect(rendered_hash['internal_route_vip_range']).to eq('127.128.0.0/9')
+        end
+
+        describe 'when a range is specified in manifest properties' do
+          it 'validates they are valid CIDRs' do
+            cc_networking_link.properties['cc']['internal_route_vip_range'] = '10.16.255.0/777'
+            expect { YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            }.to raise_error(StandardError, 'invalid cc.internal_route_vip_range: 10.16.255.0/777')
+          end
+
+          it 'does not allow ipv6 addresses' do
+            cc_networking_link.properties['cc']['internal_route_vip_range'] = '2001:0db8:85a3:0000:0000:8a2e:0370:7334/21'
+            expect { YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            }.to raise_error(StandardError, 'invalid cc.internal_route_vip_range: 2001:0db8:85a3:0000:0000:8a2e:0370:7334/21')
+          end
+
+          it 'renders valid CIDRs' do
+            cc_networking_link.properties['cc']['internal_route_vip_range'] = '10.16.255.0/24'
+            rendered_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            expect(rendered_hash['internal_route_vip_range']).to eq('10.16.255.0/24')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[#161849257]

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
These changes include a PR to cloud controller that allow the VIPs it generates to be sent to envoy. In addition to that PR, we are also introducing some bosh links to the cc route syncer job from cloud controller. The cloud controller job already provides the field `internal_route_vip_range`, which the route syncer needs in order to correctly determine VIPs. 

* An explanation of the use cases your change solves
This change allows the cc route syncer to successfully accept VIPs from cloud controller. This change also makes it so that we no longer use hard-coded vips, which prevents collision.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1361

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite

Regards,
The CF Networking Team