### PR TITLE
Add Eirini mTLS properties to CC clock and worker

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -59,22 +59,6 @@ properties:
   system_domain:
     description: "Domain reserved for CF operator, base URL where the login, uaa, and other non-user apps listen"
 
-  cc.opi.enabled:
-    description: "Set to true to enable running apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.opi_staging:
-    description: "Set to true to enable staging apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.url:
-    description: "URL of the Eirini server"
-    default: ""
-  cc.opi.client_cert:
-    description: "Client certificate for connecting to the OPI server"
-  cc.opi.client_key:
-    description: "Client key for connecting to the OPI server"
-  cc.opi.ca_cert:
-    description: "The ca cert of the OPI server"
-
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -27,6 +27,10 @@ templates:
   db_ca.crt.erb: config/certs/db_ca.crt
   credhub_ca.crt.erb: config/certs/credhub_ca.crt
 
+  opi_tls.crt.erb: config/certs/opi_tls.crt
+  opi_tls.key.erb: config/certs/opi_tls.key
+  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
+
 packages:
   - capi_utils
   - cloud_controller_ng
@@ -64,6 +68,12 @@ properties:
   cc.opi.url:
     description: "URL of the Eirini server"
     default: ""
+  cc.opi.client_cert:
+    description: "Client certificate for connecting to the OPI server"
+  cc.opi.client_key:
+    description: "Client key for connecting to the OPI server"
+  cc.opi.ca_cert:
+    description: "The ca cert of the OPI server"
 
   cc.external_port:
     description: "External Cloud Controller port"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -291,10 +291,10 @@ diego:
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:
-  url: "<%= p("cc.opi.url") %>"
-  opi_staging: <%= p("cc.opi.opi_staging") %>
-  enabled: <%= p("cc.opi.enabled") %>
-<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
+  url: "<%= link("cloud_controller_internal").p("cc.opi.url") %>"
+  opi_staging: <%= link("cloud_controller_internal").p("cc.opi.opi_staging") %>
+  enabled: <%= link("cloud_controller_internal").p("cc.opi.enabled") %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
   ca_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls_ca.crt
   client_cert_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.crt
   client_key_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.key

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -294,6 +294,11 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
+<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
+  ca_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls_ca.crt
+  client_cert_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.crt
+  client_key_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.key
+<% end %>
 
 <% if p("routing_api.enabled") %>
 routing_api:

--- a/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_cert") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.client_cert") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_cert") do |certificate| %>
 <%= certificate %>
 <% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.key.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.client_key") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_key") do |certificate| %>
 <%= certificate %>
 <% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.key.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_key") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.ca_cert") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.ca_cert") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.ca_cert") do |certificate| %>
 <%= certificate %>
 <% end %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -169,6 +169,12 @@ provides:
   - cc.logging_max_retries
   - cc.max_labels_per_resource
   - cc.max_annotations_per_resource
+  - cc.opi.ca_cert
+  - cc.opi.client_cert
+  - cc.opi.client_key
+  - cc.opi.enabled
+  - cc.opi.opi_staging
+  - cc.opi.url
   - cc.packages.app_package_directory_key
   - cc.packages.blobstore_type
   - cc.packages.cdn.key_pair_id

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -36,6 +36,10 @@ templates:
   copilot.crt.erb: config/certs/copilot.crt
   copilot.key.erb: config/certs/copilot.key
 
+  opi_tls.crt.erb: config/certs/opi_tls.crt
+  opi_tls.key.erb: config/certs/opi_tls.key
+  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
+
 packages:
   - capi_utils
   - cloud_controller_ng
@@ -79,6 +83,12 @@ properties:
   cc.opi.url:
     description: "URL of the Eirini server"
     default: ""
+  cc.opi.client_cert:
+    description: "Client certificate for connecting to the OPI server"
+  cc.opi.client_key:
+    description: "Client key for connecting to the OPI server"
+  cc.opi.ca_cert:
+    description: "The ca cert of the OPI server"
 
   cc.external_port:
     description: "External Cloud Controller port"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -74,22 +74,6 @@ properties:
   nfs_server.address:
     description: "NFS server for droplets and apps (not used in an AWS deploy, use s3 instead)"
 
-  cc.opi.enabled:
-    description: "Set to true to enable running apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.opi_staging:
-    description: "Set to true to enable staging apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.url:
-    description: "URL of the Eirini server"
-    default: ""
-  cc.opi.client_cert:
-    description: "Client certificate for connecting to the OPI server"
-  cc.opi.client_key:
-    description: "Client key for connecting to the OPI server"
-  cc.opi.ca_cert:
-    description: "The ca cert of the OPI server"
-
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -265,10 +265,10 @@ diego:
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
 opi:
-  url: "<%= p("cc.opi.url") %>"
-  opi_staging: <%= p("cc.opi.opi_staging") %>
-  enabled: <%= p("cc.opi.enabled") %>
-<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
+  url: "<%= link("cloud_controller_internal").p("cc.opi.url") %>"
+  opi_staging: <%= link("cloud_controller_internal").p("cc.opi.opi_staging") %>
+  enabled: <%= link("cloud_controller_internal").p("cc.opi.enabled") %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
   ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls_ca.crt
   client_cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.crt
   client_key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.key

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -268,6 +268,11 @@ opi:
   url: "<%= p("cc.opi.url") %>"
   opi_staging: <%= p("cc.opi.opi_staging") %>
   enabled: <%= p("cc.opi.enabled") %>
+<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
+  ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls_ca.crt
+  client_cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.crt
+  client_key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.key
+<% end %>
 
 <% if p("routing_api.enabled") %>
 routing_api:

--- a/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_cert") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.client_cert") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_cert") do |certificate| %>
 <%= certificate %>
 <% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.key.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.client_key") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.client_key") do |certificate| %>
 <%= certificate %>
 <% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.key.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.client_key") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("cc.opi.ca_cert") do |certificate| %>
+<%= certificate %>
+<% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
@@ -1,3 +1,3 @@
-<% if_p("cc.opi.ca_cert") do |certificate| %>
+<% link("cloud_controller_internal").if_p("cc.opi.ca_cert") do |certificate| %>
 <%= certificate %>
 <% end %>


### PR DESCRIPTION
Related to this merged PR: https://github.com/cloudfoundry/capi-release/pull/143

We forgot to add these properties for the worker and clock jobs as well, oops.

Saw there was some discussion around how to deploy all the Eirini stuff with BOSH, so if you all need help with that for validating these changes, definitely feel free to let us know here and we'd be happy to pair or something to assist. 

Thanks,
Jwal + @madamkiwi 