### PR TITLE
Consume file-server link with HTTPS URL

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -51,6 +51,9 @@ consumes:
   optional: true
 - name: cloud_controller_internal
   type: cloud_controller_internal
+- name: file_server
+  type: file_server
+  optional: true
 
 properties:
   ccdb.databases:

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -99,10 +99,19 @@ copilot:
   client_chain_file: /var/vcap/jobs/cc_deployment_updater/config/certs/copilot.crt
 <% end %>
 
+<%
+file_server_url = p("cc.diego.file_server_url")
+if_link("file_server") do |file_server|
+  if file_server.p("https_server_enabled")
+    file_server_url = file_server.p("https_url")
+  end
+end
+%>
+
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
   enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
-  file_server_url: <%= p("cc.diego.file_server_url") %>
+  file_server_url: <%= file_server_url %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -50,6 +50,9 @@ consumes:
 - name: cloud_controller_internal
   type: cloud_controller_internal
   optional: true
+- name: file_server
+  type: file_server
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -291,10 +291,19 @@ default_app_ssh_access: <%= p("cc.default_app_ssh_access") %>
 
 skip_cert_verify: <%= p("ssl.skip_cert_verify") %>
 
+<%
+file_server_url = p("cc.diego.file_server_url")
+if_link("file_server") do |file_server|
+  if file_server.p("https_server_enabled")
+    file_server_url = file_server.p("https_url")
+  end
+end
+%>
+
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
   enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
-  file_server_url: <%= p("cc.diego.file_server_url") %>
+  file_server_url: <%= file_server_url %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -245,6 +245,9 @@ consumes:
 - name: log-cache
   type: log-cache
   optional: true
+- name: file_server
+  type: file_server
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -426,6 +426,13 @@ if_link("cc_uploader") do |cc_uploader|
 end.else do
   cc_uploader_url = p("cc.diego.cc_uploader_https_url")
 end
+
+file_server_url = p("cc.diego.file_server_url")
+if_link("file_server") do |file_server|
+  if file_server.p("https_server_enabled")
+    file_server_url = file_server.p("https_url")
+  end
+end
 %>
 
 diego:
@@ -439,7 +446,7 @@ diego:
     receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   cc_uploader_url: <%= cc_uploader_url %>
   docker_staging_stack: <%= p("cc.diego.docker_staging_stack") %>
-  file_server_url: <%= p("cc.diego.file_server_url") %>
+  file_server_url: <%= file_server_url %>
   insecure_docker_registry_list: <%= p("cc.diego.insecure_docker_registry_list") %>
   lifecycle_bundles: <%= p("cc.diego.lifecycle_bundles").to_json %>
   droplet_destinations: <%= p("cc.diego.droplet_destinations").to_json %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -62,6 +62,9 @@ consumes:
 - name: cloud_controller_internal
   type: cloud_controller_internal
   optional: true
+- name: file_server
+  type: file_server
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -264,10 +264,19 @@ bits_service:
   ca_cert_path: /var/vcap/jobs/cloud_controller_worker/config/certs/bits_service_ca.crt
   <% end %>
 
+<%
+file_server_url = p("cc.diego.file_server_url")
+if_link("file_server") do |file_server|
+  if file_server.p("https_server_enabled")
+    file_server_url = file_server.p("https_url")
+  end
+end
+%>
+
 diego:
   temporary_oci_buildpack_mode: <%= p("cc.diego.temporary_oci_buildpack_mode", nil) %>
   enable_declarative_asset_downloads: <%= p("cc.diego.enable_declarative_asset_downloads") %>
-  file_server_url: <%= p("cc.diego.file_server_url") %>
+  file_server_url: <%= file_server_url %>
   cc_uploader_url: <%= p("cc.diego.cc_uploader_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>


### PR DESCRIPTION
Consume File Server HTTPS URL provided by Diego release if File Server is running in HTTPS mode. This provides security for communication with File Server. Default to the specified property if link is not provided.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite

Original Diego story: https://www.pivotaltracker.com/story/show/165913951

@cloudfoundry/cf-diego 
