### PR TITLE
Remove support for the "windows2016" stack

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -162,7 +162,6 @@ properties:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
-      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
@@ -170,7 +169,6 @@ properties:
       "cflinuxfs3": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
-      "windows2016": "/Users/vcap"
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -517,7 +517,6 @@ properties:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
-      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
@@ -525,7 +524,6 @@ properties:
       "cflinuxfs3": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
-      "windows2016": "/Users/vcap"
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1055,7 +1055,6 @@ properties:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
-      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
@@ -1063,7 +1062,6 @@ properties:
       "cflinuxfs3": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
-      "windows2016": "/Users/vcap"
   cc.diego.insecure_docker_registry_list:
     description: "An array of insecure Docker registries in the form of <HOSTNAME|IP>:PORT"
     default: []

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -521,7 +521,6 @@ properties:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
-      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
@@ -529,7 +528,6 @@ properties:
       "cflinuxfs3": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
-      "windows2016": "/Users/vcap"
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"
     default: ~


### PR DESCRIPTION
The "windows2016" stack has been deprecated for a long
time in favor of the "windows" stack. The newer "windows"
stack is a simple name change of the old "windows2016"
stack. This change will cause all apps running on the
"windows2016" stack to break.

See https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html#-available-stacks

https://www.pivotaltracker.com/story/show/166852962

CATS passed.

cc @Cara-Sciorilli @yaelharel @jro-pv