### PR TITLE
Add log cache url to root info

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -155,6 +155,9 @@ loggregator:
 log_stream:
   url: https://log-stream.<%= p("system_domain") %>
 
+log_cache:
+  url: https://log-cache.<%= p("system_domain") %>
+
 doppler:
   url: ws<%= "s" if p("doppler.use_ssl") %>://doppler.<%= p("system_domain") %>:<%= p("doppler.port") %>
 


### PR DESCRIPTION
[#168083320]

Signed-off-by: Caitlyn Yu <cyu@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add the log-cache url to templates

* An explanation of the use cases your change solves
Promotes log-cache to first class citizen (CF CLI wants).

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1426

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
