### PR TITLE
bump libpq to postgres 11.5

### DIFF
--- a/packages/libpq/README.md
+++ b/packages/libpq/README.md
@@ -6,4 +6,4 @@ This file can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| postgresql-9.6.8.tar.gz | https://ftp.postgresql.org/pub/source/v9.6.8/postgresql-9.6.8.tar.gz |
+| postgresql-11.5.tar.gz  | https://ftp.postgresql.org/pub/source/v11.5/postgresql-11.5.tar.gz |

--- a/packages/libpq/packaging
+++ b/packages/libpq/packaging
@@ -2,7 +2,7 @@
 
 function main() {
   local pgversion
-  pgversion="postgresql-9.6.8"
+  pgversion="postgresql-11.5"
 
   tar xzf "postgres/${pgversion}.tar.gz"
 

--- a/packages/libpq/spec
+++ b/packages/libpq/spec
@@ -1,4 +1,4 @@
 ---
 name: libpq
 files:
-- postgres/postgresql-9.6.8.tar.gz
+- postgres/postgresql-11.5.tar.gz


### PR DESCRIPTION
cf-deployment currently uses [postgres-release 39](https://github.com/cloudfoundry/postgres-release/releases), which comes with postgres 11.5.

libpq in capi-release is still on postgres 9.6. According to postgres its best practice to have the client library at least on the level of the server. Newer version of the postgres client / libpq are backward compatible, the server may not be backword compatible. Therefore it would be good to bump libpq in capi-release to the same level as postgres in postgres release.

I have run CC unit tests against a local postgres 11.5 on a macbook. I have also run CATs on bosh-lite with the update capi-release in the branch.

libpq reports postgres 11.5:
```
api/dd4e9481-64c6-436d-bf71-40818f3a5dcf:~# /var/vcap/packages/libpq/bin/pg_config --version
PostgreSQL 11.5
```

Cats result:
```
Ran 83 of 213 Specs in 2205.708 seconds
SUCCESS! -- 83 Passed | 0 Failed | 1 Pending | 129 Skipped
```