### PR TITLE
Add `route_services_enabled` to worker config

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -225,6 +225,7 @@ provides:
   - credhub_api.ca_cert
   - credhub_api.hostname
   - release_level_backup
+  - router.route_services_secret
   - routing_api.enabled
   - ssl.skip_cert_verify
   - system_domain

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -65,6 +65,7 @@ nginx:
 index: <%= spec.index %>
 name: <%= name %>
 volume_services_enabled: <%= link("cloud_controller_internal").p("cc.volume_services_enabled") %>
+route_services_enabled: <%= ! link("cloud_controller_internal").p("router.route_services_secret").empty? %>
 
 logging:
   file: /var/vcap/sys/log/cloud_controller_worker/cloud_controller_worker.log


### PR DESCRIPTION
The equivalent change was made in cloud_controller_ng by: https://github.com/cloudfoundry/cloud_controller_ng/commit/2eeee4ff1fe4deba2455993ddf9795fc389468c4

[Here's why we need it in the worker config](https://github.com/cloudfoundry/cloud_controller_ng/commit/2eeee4ff1fe4deba2455993ddf9795fc389468c4#commitcomment-35949858)

Co-authored-by: George Blue <gblue@pivotal.io>