### PR TITLE
Remove duplicate YAML field in spec

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -237,7 +237,6 @@ consumes:
 - name: cc_uploader
   type: cc_uploader
   optional: true
-  optional: true
 - name: credhub
   type: credhub
   optional: true


### PR DESCRIPTION
Hi. I noticed this when parsing the file with go (the YAML library errored on the duplicate field).