### PR TITLE
Enable second token_secret for symmetric key rotation

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -687,7 +687,9 @@ properties:
     description: "The period in seconds after which idle connections are validated, passed directly to the Sequel gem - see http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html for details.  Note that setting this to -1 results in an additional query whenever connections are checked out from the pool, which can have performance implications"
 
   uaa.cc.token_secret:
-    description: "Symmetric secret used to decode uaa tokens. Used for testing."
+    description: "Symmetric secret used to decode uaa tokens."
+  uaa.cc.token_secret2:
+    description: "Second Symmetric secret used to decode uaa tokens. Used for secret rotation."
   uaa.url:
     description: "URL of the UAA server"
   uaa.ca_cert:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -207,6 +207,9 @@ uaa:
   <% if_p("uaa.cc.token_secret") do |token_secret| %>
   symmetric_secret: "<%= token_secret %>"
   <% end %>
+  <% if_p("uaa.cc.token_secret2") do |token_secret2| %>
+  symmetric_secret2: "<%= token_secret2 %>"
+  <% end %>
 
 <% if p("routing_api.enabled") %>
 routing_api:


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: Enable settting a second token_secret to be able to rotate symmetric keys in UAA

* An explanation of the use cases your change solves: there was not the ability to rotate UAA symmetric keys prior to this without downtime.

* Links to any other associated PRs: related change in cloud_controller_ng is here ... https://github.com/cloudfoundry/cloud_controller_ng/pull/1512


* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
