### PR TITLE
Make DYNO and some nginx configuration elements configurable.

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -253,6 +253,18 @@ consumes:
   optional: true
 
 properties:
+  export_dyno:
+    description: "Flag. When true export job name and index to DYNO environment variable"
+    default: true
+
+  use_newrelic:
+    description: "Flag. When true use the Nginx newrelic plugin"
+    default: true
+
+  use_nginx_maintenance:
+    description: "Flag. When true run Nginx maintenance jobs"
+    default: true
+
   ssl.skip_cert_verify:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false

--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -20,7 +20,9 @@ cloud_controller_ng_config = {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
     "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
     "C_INCLUDE_PATH" => "/var/vcap/packages/libpq/include",
+<% if p("export_dyno") %>
     "DYNO" => "#{spec.job.name}-#{spec.index}",
+<% end %>
     "HOME" => "/home/vcap",
     "LANG" => "en_US.UTF-8",
     "LIBRARY_PATH" => "/var/vcap/packages/libpq/lib",
@@ -79,8 +81,12 @@ config = {
   "processes" => [
     cloud_controller_ng_config,
     nginx_config,
+<% if p("use_newrelic") %>
     nginx_newrelic_plugin_config,
+<% end %>
+<% if p("use_nginx_maintenance") %>
     nginx_maintenance_config,
+<% end %>
     ccng_monit_http_healthcheck_config,
   ]
 }


### PR DESCRIPTION
New properties `export_dyno`, `use_newrelic`, and `use_nginx_maintenance` to disable various things. All default to true, activating the standard behaviour. The change allows SUSE to disable the parts not required/wanted in their containerization without having to patch system sources, i.e. the config file in this case. After the change this can be done properly via ops files changing the relevant properties.

Origin ticket: cloudfoundry-incubator/kubecf#504 (Links to (semi-)related PRs).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
