### PR TITLE
Fix ownership of log file.

### DIFF
--- a/jobs/cloud_controller_ng/templates/post-start.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-start.sh.erb
@@ -61,6 +61,7 @@ function install_buildpacks {
 }
 
 function main {
+  chown vcap:vcap "/var/vcap/sys/log/cloud_controller_ng/cloud_controller_ng.log"
   install_buildpacks
   fix_bundler_home_permissions
 }


### PR DESCRIPTION
Fix ownership of log file to survive in environments with stricter permission checks.

Origin ticket: cloudfoundry-incubator/kubecf#504 (Links to (semi-)related PRs).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
