### PR TITLE
fix: Make the application of an ulimit to open fds configurable.

### DIFF
--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -29,10 +29,6 @@ provides:
     - https_port
 
 properties:
-  set_ulimit_fds:
-    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
-    default: true
-
   internal_hostname:
     description: "Hostname by which clients will communicate with the cc uploader"
     default: cc-uploader.service.cf.internal
@@ -80,3 +76,7 @@ properties:
     description: "PEM-encoded certificate for secure, mutually authenticated TLS communication"
   capi.cc_uploader.mutual_tls.server_key:
     description: "PEM-encoded key for secure, mutually authenticated TLS communication"
+
+  capi.cc_uploader.set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true

--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -29,6 +29,10 @@ provides:
     - https_port
 
 properties:
+  set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true
+
   internal_hostname:
     description: "Hostname by which clients will communicate with the cc uploader"
     default: cc-uploader.service.cf.internal

--- a/jobs/cc_uploader/templates/cc_uploader_ctl.erb
+++ b/jobs/cc_uploader/templates/cc_uploader_ctl.erb
@@ -40,7 +40,7 @@ case $1 in
         echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
     fi
 
-<% if p("set_ulimit_fds") %>
+<% if p("capi.cc_uploader.set_ulimit_fds") %>
     # Allowed number of open file descriptors
     ulimit -n 100000
 <% end %>

--- a/jobs/cc_uploader/templates/cc_uploader_ctl.erb
+++ b/jobs/cc_uploader/templates/cc_uploader_ctl.erb
@@ -40,8 +40,10 @@ case $1 in
         echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
     fi
 
+<% if p("set_ulimit_fds") %>
     # Allowed number of open file descriptors
     ulimit -n 100000
+<% end %>
 
     # Work around for GOLANG 1.5.3 DNS bug
     export GODEBUG=netdns=cgo

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -253,6 +253,10 @@ consumes:
   optional: true
 
 properties:
+  set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true
+
   ssl.skip_cert_verify:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -253,10 +253,6 @@ consumes:
   optional: true
 
 properties:
-  set_ulimit_fds:
-    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
-    default: true
-
   ssl.skip_cert_verify:
     description: "specifies that the job is allowed to skip ssl cert verification"
     default: false
@@ -364,6 +360,10 @@ properties:
     description: "The longest this job can take before it is cancelled"
   cc.jobs.droplet_upload.timeout_in_seconds:
     description: "The longest this job can take before it is cancelled"
+
+  cc.set_ulimit_fds:
+    description: "Set an ulimit on the number of open file descriptors. NOTE: set this property to 'false' when deploying to a containerized cloud"
+    default: true
 
   cc.temporary_disable_deployments:
     description: "Do not allow the API client to create app deployments (temporary)"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_api_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_api_ctl.erb
@@ -53,7 +53,7 @@ case $1 in
   start)
     setup_environment
 
-<% if p("set_ulimit_fds") %>
+<% if p("cc.set_ulimit_fds") %>
     ulimit -c unlimited
 <% end %>
 

--- a/jobs/cloud_controller_ng/templates/cloud_controller_api_ctl.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_api_ctl.erb
@@ -53,7 +53,9 @@ case $1 in
   start)
     setup_environment
 
+<% if p("set_ulimit_fds") %>
     ulimit -c unlimited
+<% end %>
 
     pid_guard "$PIDFILE" "Cloud controller ng"
 


### PR DESCRIPTION
New property `set_ulimit_fds` to disable ulimiting.
Defaults to true, activating the ulimit for standard behaviour.

The change allows SUSE to disable the application of the limit in their containerization (where it interferes) without having to patch system sources. After the change this can be done properly via ops files changing the relevant properties.

Origin ticket: cloudfoundry-incubator/kubecf#504
Origin ticket: cloudfoundry-incubator/kubecf#505
See also https://github.com/cloudfoundry/diego-release/pull/512

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
