### PR TITLE
Revise the cc-uploader pre-start.erb to allow execution within a containerized deployment.

### DIFF
--- a/jobs/cc_uploader/templates/pre-start.erb
+++ b/jobs/cc_uploader/templates/pre-start.erb
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+source /var/vcap/packages/capi_utils/container_utils.sh
+
 if [ -f /var/vcap/jobs/bosh-dns/bin/is-system-resolver ]; then
   if (/var/vcap/jobs/bosh-dns/bin/is-system-resolver); then
     echo "waiting for bosh_dns"
@@ -7,5 +9,9 @@ if [ -f /var/vcap/jobs/bosh-dns/bin/is-system-resolver ]; then
   fi
 fi
 
-sysctl -e -w net.ipv4.tcp_fin_timeout=10
-sysctl -e -w net.ipv4.tcp_tw_reuse=1
+if running_in_container; then
+    echo "Not setting /proc/sys/net/ipv4 parameters, since I'm running inside a linux container"
+else
+    sysctl -e -w net.ipv4.tcp_fin_timeout=10
+    sysctl -e -w net.ipv4.tcp_tw_reuse=1
+fi


### PR DESCRIPTION
See ticket https://github.com/cloudfoundry-incubator/kubecf/issues/520 for the origin.

This PR revises the cc-uploader's `pre-start.erb` script to allow execution within a containerized deployment. It uses the same mechanism as seen in the `cc_uploader_ctl.erb` script (lines 8, 24-41) to detect execution within a container and prevent the kernel re-configuration forbidden by that environment. The original local patch simply removed these commands, leaving something which would not work in BOSH anymore. The change proposed here should not have that failing.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have run CF Acceptance Tests on bosh lite

I have run a kubecf (containerized) deployment and smoke tests.
Both were :heavy_check_mark: 
