### PR TITLE
Update cc.system_hostnames default

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -989,7 +989,7 @@ properties:
 
   cc.system_hostnames:
     description: "List of hostnames for which routes cannot be created on the system domain."
-    default: [api,proxy,uaa,login,blobstore,log-cache,doppler,log-stream,credhub]
+    default: [api,proxy,uaa,login,blobstore,log-cache,doppler,log-stream,credhub,ssh]
 
   cc.bits_service.enabled:
     description: "Enable integration of the bits-service incubator (experimental)"

--- a/scripts/detect-system-host-routes.sh
+++ b/scripts/detect-system-host-routes.sh
@@ -4,7 +4,7 @@ set -e
 
 api_url=$(cf api | head -n 1 | awk '{ print $3; }')
 system_domain="${api_url#https://api.}"
-system_hostnames=("api" "proxy" "uaa" "login" "blobstore" "log-cache" "doppler" "log-stream" "credhub")
+system_hostnames=("api" "proxy" "uaa" "login" "blobstore" "log-cache" "doppler" "log-stream" "credhub" "ssh")
 detect_invalid_private_domains=()
 for hostname in "${system_hostnames[@]}"; do
   system_component_domain="${hostname}.${system_domain}"


### PR DESCRIPTION
Currently cloud_controller_ng.yml has `ssh.<system_domain>` set as the endpoint for `cf ssh`.
https://github.com/cloudfoundry/capi-release/blob/44247ddb4398f6ae4bc057ca74207787e6fbb15a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb#L120

There is no problem in the case where gorouter and ssh-proxy are co-located in the same VM like bosh-lite environment,
but if not, all access to `ssh.<system_domain>` reaches ssh-proxy.
I think it is necessary to register as system_hostnames.
