### PR TITLE
Add config parameter to get fog debug loggings 

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -411,6 +411,9 @@ properties:
   cc.logging_level:
     default: "info"
     description: "Log level for cc. Valid levels are listed here: https://github.com/cloudfoundry/steno#log-levels."
+  cc.logging_fog_requests:
+    default: false
+    description: "Log fog requests and responses."
   cc.logging_max_retries:
     default: 1
     description: "Passthru value for Steno logger"

--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -34,6 +34,12 @@ if !!properties.cc.newrelic.license_key || p("cc.development_mode")
     cloud_controller_ng_config["env"]["NEWRELIC_ENABLE"] = true
 end
 
+if p("cc.logging_fog_requests")
+    cloud_controller_ng_config["env"]["DEBUG"] = true
+    cloud_controller_ng_config["env"]["EXCON_DEBUG"] = true
+    cloud_controller_ng_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
+end
+
 if properties.env
     if properties.env.http_proxy
         cloud_controller_ng_config["env"]["HTTP_PROXY"] = "#{properties.env.http_proxy}"
@@ -106,6 +112,12 @@ config = {
 
   if !!properties.cc.newrelic.license_key
    local_worker_config["env"]["NEWRELIC_ENABLE"] = true
+  end
+
+  if p("cc.logging_fog_requests")
+   local_worker_config["env"]["DEBUG"] = true
+   local_worker_config["env"]["EXCON_DEBUG"] = true
+   local_worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
   end
 
   config["processes"] << local_worker_config

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -113,6 +113,9 @@ properties:
   cc.logging_level:
     default: "info"
     description: "Log level for cc. Valid levels are listed here: https://github.com/cloudfoundry/steno#log-levels."
+  cc.logging_fog_requests:
+    default: false
+    description: "Log fog requests and responses."
   cc.logging_max_retries:
     default: 1
     description: "Passthru value for Steno logger"

--- a/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -33,6 +33,12 @@ config = { "processes" => [] }
    worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
+  if p("cc.logging_fog_requests")
+    worker_config["env"]["DEBUG"] = true
+    worker_config["env"]["EXCON_DEBUG"] = true
+    worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
+  end
+
   config["processes"] << worker_config
 end
 


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
We'd like to add environment variable to get more fog debug loggings when cc.logging_level is set to debug.
We opted for a reuse of the variable to keep the config of cc simple.

  The documented behaviour of fog is that debug logging is activated when setting the DEBUG env variable of the process, see http://fog.io/about/getting_started.html.
* An explanation of the use cases your change solves
After adding the environment variable, we can get more fog debug loggings.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
No, I just tested it on several sap landscapes.
