### PR TITLE
Add `FOG_DEBUG` env var and distinguish different providers

### DIFF
--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -12,6 +12,22 @@ def mount_nfs_volume!(config)
   end
 end
 
+def enable_fog_debugging!(config)
+    if p("cc.log_fog_requests")
+        case p("cc.packages.fog_connection.provider", "").downcase
+        when "azurerm"
+          config["env"]["FOG_DEBUG"] = true
+        when  "aliyun"
+          config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
+          config["env"]["FOG_DEBUG"] = true
+          config["env"]["DEBUG"] = true
+        else
+          config["env"]["DEBUG"] = true
+          config["env"]["FOG_DEBUG"] = true
+        end
+    end
+end
+
 cloud_controller_ng_config = {
   "name" => "cloud_controller_ng",
   "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng",
@@ -34,11 +50,7 @@ if !!properties.cc.newrelic.license_key || p("cc.development_mode")
     cloud_controller_ng_config["env"]["NEWRELIC_ENABLE"] = true
 end
 
-if p("cc.log_fog_requests")
-    cloud_controller_ng_config["env"]["DEBUG"] = true
-    cloud_controller_ng_config["env"]["EXCON_DEBUG"] = true
-    cloud_controller_ng_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
-end
+enable_fog_debugging!(cloud_controller_ng_config)
 
 if properties.env
     if properties.env.http_proxy
@@ -114,11 +126,7 @@ config = {
    local_worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
-  if p("cc.log_fog_requests")
-   local_worker_config["env"]["DEBUG"] = true
-   local_worker_config["env"]["EXCON_DEBUG"] = true
-   local_worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
-  end
+  enable_fog_debugging!(local_worker_config)
 
   config["processes"] << local_worker_config
 end

--- a/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -34,10 +34,18 @@ config = { "processes" => [] }
   end
 
   if p("cc.log_fog_requests")
-    worker_config["env"]["DEBUG"] = true
-    worker_config["env"]["EXCON_DEBUG"] = true
-    worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
-  end
+        case p("cc.packages.fog_connection.provider", "").downcase
+        when "azurerm"
+          worker_config["env"]["FOG_DEBUG"] = true
+        when  "aliyun"
+          worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
+          worker_config["env"]["FOG_DEBUG"] = true
+          worker_config["env"]["DEBUG"] = true
+        else
+          worker_config["env"]["DEBUG"] = true
+          worker_config["env"]["FOG_DEBUG"] = true
+        end
+    end
 
   config["processes"] << worker_config
 end

--- a/spec/cloud_controller_ng/bpm_spec.rb
+++ b/spec/cloud_controller_ng/bpm_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+module Bosh::Template::Test
+  describe 'bpm job template rendering' do
+
+    def expect_default_debug_env_vars(results)
+      expect(results[0]['env'].key?('DEBUG')).to eq(true)
+      expect(results[0]['env'].key?('FOG_DEBUG')).to eq(true)
+      expect(results[0]['env'].key?('ALIYUN_OSS_SDK_LOG_LEVEL')).to eq(false)
+      expect(results[0]['env']['DEBUG']).to eq(true)
+      expect(results[0]['env']['FOG_DEBUG']).to eq(true)
+    end
+
+    let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+    let(:release) { ReleaseDir.new(release_path) }
+    let(:job) { release.job('cloud_controller_ng') }
+
+    let(:properties_debug_gcp) do
+      {'cc' => {'log_fog_requests' => true, 'packages' => {'fog_connection' => { 'provider' => 'Google'} }}}
+      end
+    let(:properties_debug_azure) do
+      {'cc' => {'log_fog_requests' => true, 'packages' => {'fog_connection' => { 'provider' => 'AzureRm'} }}}
+      end
+    let(:properties_debug_ali) do
+      {'cc' => {'log_fog_requests' => true, 'packages' => {'fog_connection' => { 'provider' => 'aliyun'} }}}
+    end
+    let(:properties_debug_foo) do
+      {'cc' => {'log_fog_requests' => true, 'packages' => {'fog_connection' => { 'provider' => 'foo'} }}}
+    end
+    let(:properties_without_debug) do
+      {'cc' => {'log_fog_requests' => false, 'packages' => {'fog_connection' => { 'provider' => 'aliyun'} }}}
+    end
+
+    describe 'config/bpm.yml' do
+      let(:template) { job.template('config/bpm.yml') }
+
+      context 'when fog debug logging is enabled' do
+        it 'sets the DEBUG env var for GCP' do
+          template_hash = YAML.safe_load(template.render(properties_debug_gcp, consumes: { } ))
+
+          results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+          expect(results.length).to eq(1)
+          expect_default_debug_env_vars(results)
+        end
+
+        it 'sets the FOG_DEBUG env var for Azure' do
+          template_hash = YAML.safe_load(template.render(properties_debug_azure, consumes: { } ))
+
+          results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+          expect(results.length).to eq(1)
+          expect(results[0]['env'].key?('DEBUG')).to eq(false)
+          expect(results[0]['env'].key?('FOG_DEBUG')).to eq(true)
+          expect(results[0]['env'].key?('ALIYUN_OSS_SDK_LOG_LEVEL')).to eq(false)
+          expect(results[0]['env']['FOG_DEBUG']).to eq(true)
+        end
+
+        it 'sets the ALIYUN_OSS_SDK_LOG_LEVEL env var for Ali' do
+          template_hash = YAML.safe_load(template.render(properties_debug_ali, consumes: { } ))
+
+          results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+          expect(results.length).to eq(1)
+          expect(results[0]['env'].key?('DEBUG')).to eq(true)
+          expect(results[0]['env'].key?('FOG_DEBUG')).to eq(true)
+          expect(results[0]['env'].key?('ALIYUN_OSS_SDK_LOG_LEVEL')).to eq(true)
+          expect(results[0]['env']['ALIYUN_OSS_SDK_LOG_LEVEL']).to eq('debug')
+          expect(results[0]['env']['DEBUG']).to eq(true)
+          expect(results[0]['env']['FOG_DEBUG']).to eq(true)
+        end
+
+        it 'sets not any debug env var for Foo' do
+          template_hash = YAML.safe_load(template.render(properties_debug_foo, consumes: { } ))
+
+          results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+          expect(results.length).to eq(1)
+          expect_default_debug_env_vars(results)
+        end
+      end
+
+      context 'when fog debug logging is disabled' do
+        it 'sets not any debug env var' do
+          template_hash = YAML.safe_load(template.render(properties_without_debug, consumes: { } ))
+
+          results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+          expect(results.length).to eq(1)
+          expect(results[0]['env'].key?('DEBUG')).to eq(false )
+          expect(results[0]['env'].key?('FOG_DEBUG')).to eq(false)
+          expect(results[0]['env'].key?('ALIYUN_OSS_SDK_LOG_LEVEL')).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add `FOG_DEBUG` environment variable and add switch expression for different providers
* An explanation of the use cases your change solves
Add additional `FOG_DEBUG` environment variable for Azure blobstore(fog-azure-rm changes: https://github.com/fog/fog-azure-rm/pull/431)
Add switch expression to set different environment variables for different blobstore provider. Without this sensitive information could be leaked in the logs(i.g. when "DEBUG" is enabled on azure)

We also added a simple unit test for the bpm templating. Let us know if this can be done in a nicer way :upside_down_face:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
