### PR TITLE
Add `cc_service_key_client_name` to worker config

### DIFF
--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -260,6 +260,8 @@ uaa_client_secret: <%= p("uaa.clients.cc-service-dashboards.secret") %>
 uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>
 <% end %>
 
+cc_service_key_client_name: "cc_service_key_client"
+
 allow_app_ssh_access: <%= p("cc.allow_app_ssh_access") %>
 default_app_ssh_access: <%= p("cc.default_app_ssh_access") %>
 


### PR DESCRIPTION
Service key creation is now done asynchronously in cloud controller v3 api. 
The cloud controller broker client needs access to this property hence it needs to be present in the worker config.

cloud controller config change [PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/1989)

