### PR TITLE
Shutdown nginx timeout

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -5,7 +5,7 @@ check process cloud_controller_ng
   depends on ccng_monit_http_healthcheck
   group vcap
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
-  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for <%= p("cc.thresholds.api.restart_if_consistently_above_mb_cycles") %> cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
 
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -880,8 +880,11 @@ properties:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"
     default: 3500
   cc.thresholds.api.restart_if_consistently_above_mb:
-    description: "The cc will restart if memory remains above this threshold for 15 monit cycles"
+    description: "The cc will restart if memory remains above this threshold for n monit cycles"
     default: 3500
+  cc.thresholds.api.restart_if_consistently_above_mb_cycles:
+    description: "Monit cycles for 'restart_if_consistently_above_mb'. Default is 15 cycles"
+    default: 15
   cc.thresholds.api.restart_if_above_mb:
     description: "The cc will restart if memory remains above this threshold for 3 monit cycles"
     default: 3750

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -16,7 +16,7 @@ templates:
   cloud_controller_ng.yml.erb: config/cloud_controller_ng.yml
   blobstore_waiter.sh.erb: bin/blobstore_waiter.sh
   buildpacks_ca_cert.pem.erb: config/certs/buildpacks_ca_cert.pem
-  cc-drain.rb: bin/cc-drain
+  cc-drain.rb.erb: bin/cc-drain
   cloud_controller_api_ctl.erb: bin/cloud_controller_ng_ctl
   cloud_controller_api_health_check.erb: bin/cloud_controller_ng_health_check
   cloud_controller_api_worker_ctl.erb: bin/cloud_controller_worker_ctl
@@ -55,7 +55,7 @@ templates:
   pre-start.sh.erb: bin/pre-start
   public_upload.conf.erb: config/public_upload.conf
   resource_pool_ca_cert.pem.erb: config/certs/resource_pool_ca_cert.pem
-  restart_drain.rb: bin/restart_drain
+  restart_drain.rb.erb: bin/restart_drain
   ruby_version.sh.erb: bin/ruby_version.sh
   seed_db.sh.erb: bin/seed_db
   setup_local_blobstore.sh.erb: bin/setup_local_blobstore.sh
@@ -863,6 +863,10 @@ properties:
         location: ~ ^/v2/spaces/(.*)
         limit: 10r/s
         burst: 100
+
+  cc.nginx_drain_timeout:
+    description: "Timeout for nginx graceful shutdown in seconds. Default is 30"
+    default: 30
 
   cc.server_keepalive_timeout:
     description: "Configure keep alive timeout for connections to cloud controller. This is a temporary field used for testing."

--- a/jobs/cloud_controller_ng/templates/cc-drain.rb.erb
+++ b/jobs/cloud_controller_ng/templates/cc-drain.rb.erb
@@ -7,7 +7,7 @@ require 'cloud_controller/drain'
 
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cloud_controller_ng')
 @drain.log_invocation(ARGV)
-@drain.shutdown_nginx('/var/vcap/sys/run/nginx_cc/nginx.pid')
+@drain.shutdown_nginx('/var/vcap/sys/run/nginx_cc/nginx.pid', <%= p("cc.nginx_drain_timeout") %>)
 
 $stdout.sync = true
 puts 0 # tell bosh the drain script succeeded

--- a/jobs/cloud_controller_ng/templates/restart_drain.rb.erb
+++ b/jobs/cloud_controller_ng/templates/restart_drain.rb.erb
@@ -7,7 +7,7 @@ require 'cloud_controller/drain'
 
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cloud_controller_ng')
 @drain.log_invocation(ARGV)
-@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid')
+@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', <%= p("cc.nginx_drain_timeout") %>)
 @drain.shutdown_cc('/var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid')
 
 puts 0 # tell bosh the drain script succeeded

--- a/spec/cloud_controller_ng/drain_spec.rb
+++ b/spec/cloud_controller_ng/drain_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh::Template::Test
+  describe 'drain template rendering' do
+
+    let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+    let(:release) { ReleaseDir.new(release_path) }
+    let(:job) { release.job('cloud_controller_ng') }
+
+    describe 'bin/restart_drain' do
+      let(:template) { job.template('bin/restart_drain') }
+
+      it 'renders the default value' do
+        rendered_file = template.render(consumes: { } )
+        expect(rendered_file).to include("@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', 30)")
+      end
+
+      context 'when nginx timeout is provided' do
+        it 'renders the provided value' do
+          rendered_file = template.render({'cc' => {'nginx_drain_timeout' => 60 }}, consumes: { } )
+          expect(rendered_file).to include("@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', 60)")
+        end
+      end
+    end
+
+    describe 'bin/cc-drain' do
+      let(:template) { job.template('bin/cc-drain') }
+
+      it 'renders the default value' do
+        rendered_file = template.render(consumes: { } )
+        expect(rendered_file).to include("@drain.shutdown_nginx('/var/vcap/sys/run/nginx_cc/nginx.pid', 30)")
+      end
+
+      context 'when nginx timeout is provided' do
+        it 'renders the provided value' do
+          rendered_file = template.render({'cc' => {'nginx_drain_timeout' => 60 }}, consumes: { } )
+          expect(rendered_file).to include("@drain.shutdown_nginx('/var/vcap/sys/run/nginx_cc/nginx.pid', 60)")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
 Currently the nginx timeout for graceful shutdown is hard coded to 30 secs. If requests take longer than this (e.g. `v2/services` on big foundries) they'll be terminated. Making this configurable will allow operators to prevent (too many) failed requests during monit restarts. See `cloud_controller_ng` https://github.com/cloudfoundry/cloud_controller_ng/pull/2138.  
  For the same reason the number of monit cycles for detecting constant high memory consumption should be configurable. 

* Links to any other associated PRs:
  https://github.com/cloudfoundry/cloud_controller_ng/pull/2138

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
