### PR TITLE
Hide user guid header from client

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -21,6 +21,8 @@ http {
   access_log  /var/vcap/sys/log/cloud_controller_ng/nginx-access.log main;
   access_log  syslog:server=127.0.0.1,severity=info,tag=vcap_nginx_access main;
 
+  proxy_hide_header X-USER-GUID;  #user guid header should not be forwarded to client
+
   sendfile             on;  #enable use of sendfile()
   sendfile_max_chunk   1M;  #make sure not to block on fast clients reading large files
   tcp_nopush           on;


### PR DESCRIPTION
* A short explanation of the proposed change:
  Hide header `X-USER-GUID` from client. Header was newly introduced in cc_ng with https://github.com/cloudfoundry/cloud_controller_ng/pull/2167
  It can be used in nginx access logs, e.g. with `user_guid=$upstream_http_x_user_guid`

   This makes it easier for us track/ debug requests with the nginx logs.


* Links to any other associated PRs
  * https://github.com/cloudfoundry/cloud_controller_ng/pull/2167

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
