### PR TITLE
Allow configuration of different (i.e. json) escaping for access log

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -840,6 +840,9 @@ properties:
     default: >
       $host - [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"
       $proxy_add_x_forwarded_for vcap_request_id:$upstream_http_x_vcap_request_id response_time:$upstream_response_time
+  cc.nginx_access_log_escaping:
+    description: "The characters escaping used for logging variables: [default | json]"
+    default: default
   cc.nginx_error_log_destination:
     description: "The nginx error log destination. This can be used to route error logs to a file, syslog, or a memory buffer."
     default: "/var/vcap/sys/log/nginx_cc/nginx.error.log"

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -16,7 +16,7 @@ http {
   default_type  text/html;
   server_tokens off;
 
-  log_format main  '<%= p("cc.nginx_access_log_format").chomp %>';
+  log_format main escape=<%= p("cc.nginx_access_log_escaping") %> '<%= p("cc.nginx_access_log_format").chomp %>';
 
   access_log  /var/vcap/sys/log/cloud_controller_ng/nginx-access.log main;
   access_log  syslog:server=127.0.0.1,severity=info,tag=vcap_nginx_access main;

--- a/spec/cloud_controller_ng/nginx_spec.rb
+++ b/spec/cloud_controller_ng/nginx_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh::Template::Test
+  describe 'nginx config template rendering' do
+    let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+    let(:release) { ReleaseDir.new(release_path) }
+    let(:job) { release.job('cloud_controller_ng') }
+
+    describe 'nginx.conf' do
+      let(:template) { job.template('config/nginx.conf') }
+      let(:manifest_properties) { {} }
+
+      before do
+        @rendered_file = template.render(manifest_properties, consumes: {})
+      end
+
+      it 'renders default values' do
+        expect(@rendered_file).to include('log_format main escape=default')
+      end
+
+      context 'json escaping for access log is configured' do
+        let(:manifest_properties) { { 'cc' => { 'nginx_access_log_escaping' => 'json' } } }
+
+        it 'renders escape=json' do
+          expect(@rendered_file).to include('log_format main escape=json')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
With this PR the characters escaping used for logging variables to the nginx access log can be set to `json`. This allows changing the log format to a JSON string (e.g. `{"key":"$variable"}`) and getting properly escaped JSON logs.

* An explanation of the use cases your change solves
With Logstash the parsing of JSON-formatted logs becomes easier and is more flexible (i.e. adding a new field does not require the parser to be changed).

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
