### PR TITLE
Add configuration for connection expiration settings

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -85,6 +85,10 @@ properties:
   ccdb.connection_validation_timeout:
     default: 3600
     description: "The period in seconds after which idle connections are validated, passed directly to the Sequel gem - see http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html for details.  Note that setting this to -1 results in an additional query whenever connections are checked out from the pool, which can have performance implications"
+  ccdb.connection_expiration_timeout:
+    description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.connection_expiration_random_delay:
+    description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
 
   cc.readiness_port.deployment_updater:
     default: -1

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -73,6 +73,12 @@ db: &db
 <% if_p('ccdb.ca_cert') do %>
   ca_cert_path: '/var/vcap/jobs/cc_deployment_updater/config/certs/db_ca.crt'
 <% end %>
+<% if_p("ccdb.connection_expiration_timeout") do |expiration_timeout| %>
+  connection_expiration_timeout: <%= expiration_timeout %>
+<% end %>
+<% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
+  connection_expiration_random_delay: <%= expiration_delay %>
+<% end %>
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -372,6 +372,10 @@ properties:
   cc.default_app_ssh_access:
     default: true
     description: "When ssh is allowed and not explicitly set in the application, new applications will start with ssh service enabled"
+  ccdb.connection_expiration_timeout:
+    description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.connection_expiration_random_delay:
+    description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
 
   uaa.ca_cert:
     description: "The certificate authority being used by UAA"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -146,6 +146,12 @@ db: &db
 <% if_p('ccdb.ca_cert') do %>
   ca_cert_path: '/var/vcap/jobs/cloud_controller_clock/config/certs/db_ca.crt'
 <% end %>
+<% if_p("ccdb.connection_expiration_timeout") do |expiration_timeout| %>
+  connection_expiration_timeout: <%= expiration_timeout %>
+<% end %>
+<% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
+  connection_expiration_random_delay: <%= expiration_delay %>
+<% end %>
 
 <% system_domain = p("system_domain") %>
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -693,6 +693,10 @@ properties:
   ccdb.max_migration_duration_in_minutes:
     description: "the maximum time migrations should be allowed to run before job startup should error"
     default: 20160
+  ccdb.connection_expiration_timeout:
+    description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.connection_expiration_random_delay:
+    description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
 
   uaa.cc.token_secret:
     description: "Symmetric secret used to decode uaa tokens."

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -190,6 +190,12 @@ db: &db
 <% if_p("ccdb.ca_cert") do %>
   ca_cert_path: "/var/vcap/jobs/cloud_controller_ng/config/certs/db_ca.crt"
 <% end %>
+<% if_p("ccdb.connection_expiration_timeout") do |expiration_timeout| %>
+  connection_expiration_timeout: <%= expiration_timeout %>
+<% end %>
+<% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
+  connection_expiration_random_delay: <%= expiration_delay %>
+<% end %>
 
 <% scheme = p("login.protocol")
    system_domain = p("system_domain") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -349,6 +349,10 @@ properties:
   cc.db_encryption_key:
     default: ""
     description: "key for encrypting sensitive values in the CC database"
+  ccdb.connection_expiration_timeout:
+    description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.connection_expiration_random_delay:
+    description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
 
   cc.database_encryption.keys:
     default: {}

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -114,6 +114,12 @@ db: &db
   <% if_p("ccdb.ca_cert") do %>
   ca_cert_path: "/var/vcap/jobs/cloud_controller_worker/config/certs/db_ca.crt"
   <% end %>
+<% if_p("ccdb.connection_expiration_timeout") do |expiration_timeout| %>
+  connection_expiration_timeout: <%= expiration_timeout %>
+<% end %>
+<% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
+  connection_expiration_random_delay: <%= expiration_delay %>
+<% end %>
 
 <% system_domain = p("system_domain") %>
 

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -390,6 +390,19 @@ module Bosh::Template::Test
 
       end
 
+      context 'when db connection expiration configuration is present' do
+        before do
+          merged_manifest_properties['ccdb']['connection_expiration_timeout'] = 3600
+          merged_manifest_properties['ccdb']['connection_expiration_random_delay'] = 60
+        end
+
+        it 'sets the db expiration properties' do
+          template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+          expect(template_hash['db']['connection_expiration_timeout']).to eq(3600)
+          expect(template_hash['db']['connection_expiration_random_delay']).to eq(60)
+        end
+      end
+
       context 'when the file_server link is present' do
         let(:links) { [db_link,file_server_link] }
 

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -188,6 +188,19 @@ module Bosh::Template::Test
           })
         end
       end
+
+      context 'when db connection expiration configuration is present' do
+        before do
+          manifest_properties['ccdb']['connection_expiration_timeout'] = 3600
+          manifest_properties['ccdb']['connection_expiration_random_delay'] = 60
+        end
+
+        it 'sets the db expiration properties' do
+          template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+          expect(template_hash['db']['connection_expiration_timeout']).to eq(3600)
+          expect(template_hash['db']['connection_expiration_random_delay']).to eq(60)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Draft ready for https://github.com/cloudfoundry/cloud_controller_ng/pull/2351

## A short explanation of the proposed change:
Expose configuration of database connection expiration settings

## An explanation of the use cases your change solves
Allow BOSH users to configure DB connections to expire due to long running connections consuming and not release DB resources

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2351

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
