### PR TITLE
Add flag to toggle space supporter role

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -375,8 +375,8 @@ properties:
     description: "Enable V2 endpoints"
     default: true
 
-  cc.temporary_enable_space_application_supporter_role:
-    description: "Enables the space application supporter role. This flag will start false, eventually default to true in the future and then be removed."
+  cc.temporary_enable_space_supporter_role:
+    description: "Enables the space supporter role. This flag will start false, eventually default to true in the future and then be removed."
     default: false
 
   cc.directories.tmpdir:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -375,6 +375,10 @@ properties:
     description: "Enable V2 endpoints"
     default: true
 
+  cc.temporary_enable_space_application_supporter_role:
+    description: "Enables the space application supporter role. This flag will start false, eventually default to true in the future and then be removed."
+    default: false
+
   cc.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
     description: "The directory to use for temporary files"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -62,7 +62,7 @@ external_protocol: <%= p("cc.external_protocol") %>
 external_domain: <%= p("cc.external_host") %>.<%= p("system_domain") %>
 temporary_disable_deployments: <%= p("cc.temporary_disable_deployments") %>
 temporary_use_logcache: <%= p("cc.temporary_use_logcache") %>
-temporary_enable_space_application_supporter_role: <%= p("cc.temporary_enable_space_application_supporter_role") %>
+temporary_enable_space_supporter_role: <%= p("cc.temporary_enable_space_supporter_role") %>
 
 system_domain_organization: <%= p("system_domain_organization") %>
 system_domain: <%= p("system_domain") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -62,6 +62,7 @@ external_protocol: <%= p("cc.external_protocol") %>
 external_domain: <%= p("cc.external_host") %>.<%= p("system_domain") %>
 temporary_disable_deployments: <%= p("cc.temporary_disable_deployments") %>
 temporary_use_logcache: <%= p("cc.temporary_use_logcache") %>
+temporary_enable_space_application_supporter_role: <%= p("cc.temporary_enable_space_application_supporter_role") %>
 
 system_domain_organization: <%= p("system_domain_organization") %>
 system_domain: <%= p("system_domain") %>


### PR DESCRIPTION
Hi CAPI friends!

This is a PR to toggle the behavior of the new `space supporter` role (previously known as `space_application_supporter`). It introduces a new temporary flag in the cloud_controller_ng spec.

**NOTE**: this property hooks into a renamed property in [this CCNG PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/2375) that has not been merged yet. While that PR is not necessarily a blocker, this property will be ineffective until those changes are merged into CCNG.

Best,
Belinda