### PR TITLE
Make route registration health check fail on 4xx/5xx

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_api_health_check.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_api_health_check.erb
@@ -7,6 +7,7 @@ URL="https://localhost:${PORT}/healthz"
 
 echo $(date --rfc-3339=ns) "cloud_controller_ng_health_check: route-registrar about to curl $URL"
 curl \
+  --fail \
   --max-time <%= p('cc.api_health_check_timeout_per_retry') %> \
   --retry-max-time <%= p('cc.api_health_check_total_timeout') %> \
   --retry 100000 \


### PR DESCRIPTION
The Cloud Controller can return 4xx/5xx responses for a number of
reasons, some of which effectively mean the CC is unavailable (e.g.
nginx is returning 502 because the CC socket is not found). Adding the
`--fail` flag to cURL means that cURL will exit 22 if the /healthz
endpoint has not returned a 2xx/3xx response after all the retries. This
means that the route will not be registered/the heartbeat will fail and
traffic will not be routed to the failing CC VM.

There is likely some similar work to do in the CC monit health check
script to try and automatically repair the CC process when it is failing
but this check should at least make sure users aren't routed to an
unhealthy VM

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

## A short explanation of the proposed change
Make the health check script that route registrar calls exit non-zero ("fail") when CC returns 4xx/5xx responses, even with retries.

## An explanation of the use cases your change solves
A CC instance that is responding 4xx/5xx to `/healthz` requests is likely not healthy enough to be served traffic. Currently the route registrar script exits 0 as long as an HTTP response is received, regardless of the status of that response. By adding the `--fail` flag, route registrar will correctly deregister the route for this VM until CC starts responding healthily again.

## Before
Simulating a broken CC process by adding a sleep between process start and socket being opened, the route registrar logs say:
```
{"timestamp":"2021-07-08T09:26:29.705591422Z","level":"info","source":"Route Registrar","message":"Route Registrar.Script exited without error","data":{"script":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","stderr":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   150  100   150    0     0   7894      0 --:--:-- --:--:-- --:--:--  7894\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 100000 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   150  100   150    0     0   146k      0 --:--:-- --:--:-- --:--:--  146k\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 99999 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   150  100   150    0     0  50000      0 --:--:-- --:--:-- --:--:-- 50000\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 99998 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   150  100   150    0     0   146k      0 --:--:-- --:--:-- --:--:--  146k\n","stdout":"2021-07-08 09:26:26.652054651+00:00 cloud_controller_ng_health_check: route-registrar about to curl https://localhost:9024/healthz\n<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}}
{"timestamp":"2021-07-08T09:26:29.705810625Z","level":"info","source":"Route Registrar","message":"Route Registrar.healthchecker returned healthy for route","data":{"route":{"Type":"","Name":"api","Port":9022,"TLSPort":9024,"Tags":{"component":"CloudController"},"URIs":["api.cf.dev22.aws.bndl.sapcloud.io"],"RouterGroup":"","Host":"","ExternalPort":null,"RouteServiceUrl":"","RegistrationInterval":10000000000,"HealthCheck":{"Name":"api-health-check","ScriptPath":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","Timeout":6000000000},"ServerCertDomainSAN":"api.cf.dev22.aws.bndl.sapcloud.io"}}}
{"timestamp":"2021-07-08T09:26:29.705884397Z","level":"info","source":"Route Registrar","message":"Route Registrar.Registering route","data":{"route":{"Type":"","Name":"api","Port":9022,"TLSPort":9024,"Tags":{"component":"CloudController"},"URIs":["api.cf.dev22.aws.bndl.sapcloud.io"],"RouterGroup":"","Host":"","ExternalPort":null,"RouteServiceUrl":"","RegistrationInterval":10000000000,"HealthCheck":{"Name":"api-health-check","ScriptPath":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","Timeout":6000000000},"ServerCertDomainSAN":"api.cf.dev22.aws.bndl.sapcloud.io"}}}
{"timestamp":"2021-07-08T09:26:29.705981768Z","level":"info","source":"Route Registrar","message":"Route Registrar.Registered routes successfully","data":{}}
```
(tl;dr 502 Bad Gateway after 3 retries then `Script exited without error`)

## After
Same setup as above but including `--fail` flag:
```
{"timestamp":"2021-07-08T13:34:19.850870489Z","level":"info","source":"Route Registrar","message":"Route Registrar.Script exited with error","data":{"error":"exit status 22","script":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","stderr":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 100000 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 99999 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\nWarning: Transient problem: HTTP error Will retry in 1 seconds. 99998 retries \nWarning: left.\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\ncurl: (22) The requested URL returned error: 502 Bad Gateway\n","stdout":"2021-07-08 13:34:16.654733687+00:00 cloud_controller_ng_health_check: route-registrar about to curl https://localhost:9024/healthz\n2021-07-08 13:34:19.849818822+00:00 Failed to hit https://localhost:9024/healthz\n"}}
{"timestamp":"2021-07-08T13:34:19.850991121Z","level":"info","source":"Route Registrar","message":"Route Registrar.healthchecker returned unhealthy for route","data":{"route":{"Type":"","Name":"api","Port":9022,"TLSPort":9024,"Tags":{"component":"CloudController"},"URIs":["api.cf.dev22.aws.bndl.sapcloud.io"],"RouterGroup":"","Host":"","ExternalPort":null,"RouteServiceUrl":"","RegistrationInterval":10000000000,"HealthCheck":{"Name":"api-health-check","ScriptPath":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","Timeout":6000000000},"ServerCertDomainSAN":"api.cf.dev22.aws.bndl.sapcloud.io"}}}
{"timestamp":"2021-07-08T13:34:19.851043421Z","level":"info","source":"Route Registrar","message":"Route Registrar.Unregistering route","data":{"route":{"Type":"","Name":"api","Port":9022,"TLSPort":9024,"Tags":{"component":"CloudController"},"URIs":["api.cf.dev22.aws.bndl.sapcloud.io"],"RouterGroup":"","Host":"","ExternalPort":null,"RouteServiceUrl":"","RegistrationInterval":10000000000,"HealthCheck":{"Name":"api-health-check","ScriptPath":"/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check","Timeout":6000000000},"ServerCertDomainSAN":"api.cf.dev22.aws.bndl.sapcloud.io"}}}
{"timestamp":"2021-07-08T13:34:19.851418257Z","level":"info","source":"Route Registrar","message":"Route Registrar.Unregistered routes successfully","data":{}}
```
(tl;dr 502 Bad Gateway after 3 retried then `Script exited with error` and `Unregistering route`)

## Links to any other associated PRs
Related but not identical to https://github.com/cloudfoundry/capi-release/issues/166 

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
