### PR TITLE
Configure query size log threshold

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -418,6 +418,9 @@ properties:
   cc.log_db_queries:
     default: false
     description: "Log database queries. WARNING: Setting this to true with cc.db_logging_level >= cc.logging_level will log all field values, including encrypted secrets."
+  cc.query_size_log_threshold:
+    description: "Log when SQL queries return more than this number of rows if cc.log_db_queries is set to true"
+    example: 1000
   cc.db_logging_level:
     default: "debug2"
     description: "Level at which cc database operations will be logged if cc.log_db_queries is set to true."

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -184,6 +184,9 @@ db: &db
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: "<%= p("cc.db_logging_level") %>"
   log_db_queries: <%= p("cc.log_db_queries") %>
+<% if_p("cc.query_size_log_threshold") do %>
+  query_size_log_threshold: <%= p("cc.query_size_log_threshold") %>
+<% end %>
   ssl_verify_hostname: <%= p("ccdb.ssl_verify_hostname") %>
   read_timeout: <%= p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= p("ccdb.connection_validation_timeout") %>


### PR DESCRIPTION
## A short explanation of the proposed change:
Allow configuring of the threshold above which large queries should be logged

## An explanation of the use cases your change solves:
We want to know which endpoints are making queries that return a lot of rows which causes the main CC process to have to parse rows slowly. This is mainly an issue for the API as it slows down requests which in turn slows down other requests etc. as they are on a shared process so not going to worry about extending this config to other jobs yet.

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2338

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
