### PR TITLE
Send upload start time as form field to cloud controller

### DIFF
--- a/jobs/cloud_controller_ng/templates/public_upload.conf.erb
+++ b/jobs/cloud_controller_ng/templates/public_upload.conf.erb
@@ -16,6 +16,7 @@ upload_store_access user:r;
 # Set specified fields in request body
 upload_set_form_field "${upload_field_name}_name" $upload_file_name;
 upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
+upload_set_form_field "upload_start_time" $msec;
 
 #forward the following fields from existing body
 upload_pass_form_field "^_method$";


### PR DESCRIPTION
* A short explanation of the proposed change:

This change sends the start time of an upload as a form field through to the Cloud Controller. [This PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/2452) to the Cloud Controller would consume the form field and use it to calculate the expiry time for authentication tokens for the `/v3/packages/:guid/upload` endpoint based on upload start time.

* An explanation of the use cases your change solves

Currently users whose token is still valid at the time a package upload starts, but whose token expires before that upload finishes, are presented with a CF-InvalidAuthToken error. Although the option to set a grace period already exists, this is only useful to users who are able to easily change platform-wide configuration, and who can accurately predict the time their uploads will need. I believe it is uncommon for users to be in this position.

* Links to any other associated PRs

https://github.com/cloudfoundry/cloud_controller_ng/pull/2452

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [] I have run CF Acceptance Tests on bosh lite
