### PR TITLE
Ensure that job is unmonitored before monitoring it again

### DIFF
--- a/jobs/cloud_controller_ng/templates/restart_drain.sh.erb
+++ b/jobs/cloud_controller_ng/templates/restart_drain.sh.erb
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source /var/vcap/jobs/cloud_controller_ng/packages/capi_utils/monit_utils.sh
+
 PIDFILE="/var/vcap/sys/run/cloud_controller_ng/restart_drain.pid"
 
 # As this script might run longer than a monit cycle (10s) and thus might be
@@ -9,7 +11,7 @@ PIDFILE="/var/vcap/sys/run/cloud_controller_ng/restart_drain.pid"
 function on_exit {
     # Re-enable monitoring of ccng_monit_http_healthcheck. This also enables
     # monitoring of nginx_cc and cloud_controller_ng.
-    /var/vcap/bosh/bin/monit monitor ccng_monit_http_healthcheck
+    monit_monitor_job ccng_monit_http_healthcheck
     rm -f $PIDFILE
 }
 
@@ -22,6 +24,6 @@ echo "$(date) - pid: $BASHPID - Monit triggered shutdown drain" >> "$LOGFILE"
 # Unmonitor cloud_controller_ng. This also unmonitors nginx_cc and
 # ccng_monit_http_healthcheck. Monit should not interfere with the graceful
 # shutdown.
-/var/vcap/bosh/bin/monit unmonitor cloud_controller_ng
+monit_unmonitor_job cloud_controller_ng
 
 /var/vcap/jobs/cloud_controller_ng/bin/shutdown_drain 1>&2

--- a/src/capi_utils/monit_utils.sh
+++ b/src/capi_utils/monit_utils.sh
@@ -52,6 +52,17 @@ function wait_for_server_to_become_healthy() {
   return 1
 }
 
+# monit_monitor_job
+#
+# @param job_name
+#
+# Tells monit to monitor the given job.
+#
+function monit_monitor_job() {
+  local job_name="$1"
+  sudo /var/vcap/bosh/bin/monit monitor "${job_name}"
+}
+
 # monit_unmonitor_job
 #
 # @param job_name


### PR DESCRIPTION
In case the monitoring is triggered before the unmonitoring finished, the jobs remain in an unmonitored state. Make use of the helper function `monit_unmonitor_job` from `monit_utils.sh` as it waits until unmonitoring succeeded. Add `monit_monitor_job` function to `monit_utils.sh`.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
