### PR TITLE
Fail monit health check on 4xx/5xx responses from CC

### DIFF
--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -30,6 +30,8 @@ check process nginx_cc
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p nginx"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p nginx"
+  if failed unixsocket /var/vcap/data/cloud_controller_ng/cloud_controller.sock then restart
+  if <%= p("cc.thresholds.api.restart_if_monit_connection_test_consistently_fails_cycles") %> restarts within <%= p("cc.thresholds.api.restart_if_monit_connection_test_consistently_fails_cycles") %> cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
   depends on cloud_controller_ng
   group vcap
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -910,6 +910,9 @@ properties:
   cc.thresholds.api.restart_if_above_mb:
     description: "The cc will restart if memory remains above this threshold for 3 monit cycles"
     default: 3750
+  cc.thresholds.api.restart_if_monit_connection_test_consistently_fails_cycles:
+    description: "Number of monit cycles until a failing unixsocket test triggers a restart. Default is 60 cycles (i.e. 10 minutes)"
+    default: 60
 
   dea_next.staging_memory_limit_mb:
     description: "Memory limit in MB for staging tasks"

--- a/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
+++ b/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
@@ -40,6 +40,7 @@ trap log_failure EXIT
 while true; do
   set +e
   curl \
+    --fail \
     -sS \
     --max-time <%= p('cc.ccng_monit_http_healthcheck_timeout_per_retry') %> \
     --retry <%= p('cc.ccng_monit_http_healthcheck_retries') %> \


### PR DESCRIPTION
Although the health endpoint only returns HTTP status code 200 under normal circumstances there might be issues with either the rack middleware or nginx resulting in HTTP error response codes. Consistently failing health checks should gracefully shutdown and restart CC (as done by the `restart_drain` script).

To overcome situations when CC starts up slow (e.g. due to database overload) an additional monit check for the `nginx_cc` process has been added. As Nginx communicates with CC via a unix socket, it should not run unless the socket is ready. If the socket is unavailable for 10 minutes (configurable) a graceful shutdown and restart is triggered.

We tested the changes in this PR as follows:
- We modified the `RequestMetrics` middleware to raise an error when there were too many outstanding requests. The modified `ccng_monit_http_healthcheck` script then fails after retrying n times (n = `ccng_monit_http_healthcheck_retries`) to curl the `/healthz` endpoint. This triggers the graceful shutdown and restart through the `restart_drain` script.
- We added a sleep in `Runner.run!` before `start_thin_server`. The `cloud_controller_ng` monit process is shown as `running`, but `nginx_cc` will show `Connection failed` until the web server is started. This means that also the `ccng_monit_http_healthcheck` will only become active once everything is ready.
- To test the restart triggered by monit for a consistently failing connection test on the unix socket, we simply deleted the socket file (`rm /var/vcap/data/cloud_controller_ng/cloud_controller.sock`). Monit will restart the `nginx_cc` process again and again until `restart_if_monit_connection_test_consistently_fails_cycles` has been reached. Then the graceful shutdown and restart through the `restart_drain` script is triggered. While `nginx_cc` is failing, the `ccng_monit_http_healthcheck` remains inactive.

Fixes #166.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
