### PR TITLE
Remove `temporary_enable_space_supporter_role` flag

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -383,10 +383,6 @@ properties:
     description: "Enable V2 endpoints"
     default: true
 
-  cc.temporary_enable_space_supporter_role:
-    description: "Enables the space supporter role. This flag will start false, eventually default to true in the future and then be removed."
-    default: false
-
   cc.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"
     description: "The directory to use for temporary files"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -62,7 +62,6 @@ external_protocol: <%= p("cc.external_protocol") %>
 external_domain: <%= p("cc.external_host") %>.<%= p("system_domain") %>
 temporary_disable_deployments: <%= p("cc.temporary_disable_deployments") %>
 temporary_use_logcache: <%= p("cc.temporary_use_logcache") %>
-temporary_enable_space_supporter_role: <%= p("cc.temporary_enable_space_supporter_role") %>
 
 system_domain_organization: <%= p("system_domain_organization") %>
 system_domain: <%= p("system_domain") %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change

This flag was used while we were adding the new role, now that the role is ready to go so we can remove the flag

* Links to any other associated PRs

Issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/2469
ccng PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/2490

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
