### PR TITLE
Update request counts in database only every n requests

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1047,6 +1047,10 @@ properties:
   cc.rate_limiter.reset_interval_in_minutes:
     description: "The interval in minutes after which a user's available API requests will be reset"
     default: 60
+  cc.rate_limiter.update_db_every_n_requests:
+    description: "The number of requests per user and API node after which the database counter will be updated.
+                  Until this threshold is reached, requests are counted in-memory."
+    default: 1
 
   cc.diego.bbs.url:
     description: "URL of the BBS Server"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -437,6 +437,7 @@ rate_limiter:
   general_limit: <%= p("cc.rate_limiter.general_limit") %>
   unauthenticated_limit: <%= p("cc.rate_limiter.unauthenticated_limit") %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter.reset_interval_in_minutes") %>
+  update_db_every_n_requests: <%= p("cc.rate_limiter.update_db_every_n_requests") %>
 
 <%
 cc_uploader_url = nil


### PR DESCRIPTION
Expose new config option `cc.rate_limiter.update_db_every_n_requests` which defaults to `1`.

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
