### PR TITLE
Introduce experimental use_optimized_json_encoder configuration

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1188,6 +1188,10 @@ properties:
     description: "How many threads a single cloud controller instance's thin server will attempt to use. Alter at your own peril."
     default: 20 # inherited from default in Thin/EventMachine
 
+  cc.experimental.use_optimized_json_encoder:
+    description: "Switch to a different Ruby JSON encoder, i.e. Oj (https://github.com/ohler55/oj)."
+    default: false
+
   cc.kubernetes.host_url:
     description: "Kubernetes master API URL"
   cc.kubernetes.service_account.name:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -514,6 +514,8 @@ internal_route_vip_range: <%= internal_vip_range %>
 
 threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>
 
+use_optimized_json_encoder: <%= p("cc.experimental.use_optimized_json_encoder") %>
+
 <% if_p("cc.kubernetes.host_url") do %>
 kubernetes:
   host_url: <%= p("cc.kubernetes.host_url") %>


### PR DESCRIPTION
Expose `use_optimized_json_encoder` as an experimental config property.

Related CCNG PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/2481

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
