### PR TITLE
Revert "Send upload start time as form field to cloud controller"

### DIFF
--- a/jobs/cloud_controller_ng/templates/public_upload.conf.erb
+++ b/jobs/cloud_controller_ng/templates/public_upload.conf.erb
@@ -16,7 +16,6 @@ upload_store_access user:r;
 # Set specified fields in request body
 upload_set_form_field "${upload_field_name}_name" $upload_file_name;
 upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
-upload_set_form_field "upload_start_time" $msec;
 
 #forward the following fields from existing body
 upload_pass_form_field "^_method$";


### PR DESCRIPTION
Reverts cloudfoundry/capi-release#201

See comment on issue