### PR TITLE
Configure per-vm (in-memory) rate limit settings

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -253,6 +253,9 @@ consumes:
 - name: file_server
   type: file_server
   optional: true
+- name: cloud_controller
+  type: cloud_controller
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -432,10 +432,13 @@ bits_service:
   ca_cert_path: /var/vcap/jobs/cloud_controller_ng/config/certs/bits_service_ca.crt
   <% end %>
 
+<% instances = p("cc.rate_limiter.enabled") ? link("cloud_controller").instances.length : 1 %>
 rate_limiter:
   enabled: <%= p("cc.rate_limiter.enabled") %>
-  general_limit: <%= p("cc.rate_limiter.general_limit") %>
-  unauthenticated_limit: <%= p("cc.rate_limiter.unauthenticated_limit") %>
+  global_general_limit: <%= p("cc.rate_limiter.general_limit") %>
+  per_process_general_limit: <%= (p("cc.rate_limiter.general_limit").to_f/instances).ceil %>
+  global_unauthenticated_limit: <%= p("cc.rate_limiter.unauthenticated_limit") %>
+  per_process_unauthenticated_limit: <%= (p("cc.rate_limiter.unauthenticated_limit").to_f/instances).ceil %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter.reset_interval_in_minutes") %>
 
 <%


### PR DESCRIPTION
## A short explanation of the proposed change
Allow configuring of new in-memory rate limits from https://github.com/cloudfoundry/cloud_controller_ng/pull/2535

## An explanation of the use cases your change solves
Users should not have to make significant changes to utilise this new feature so do the calculation with Ruby/ERB to keep the "interface" of this release the same. Adds a new consuming of the cloud_controller link but this should be implicitly consumed by the CC instance group.

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2535

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
