### PR TITLE
Add service broker concurrent rate limit config

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1051,6 +1051,10 @@ properties:
     description: "The interval in minutes after which a user's available API requests will be reset"
     default: 60
 
+  cc.max_concurrent_service_broker_requests:
+    description: "Maximum number of concurrent requests to service brokers per user. Set to 0 to not limit concurrent requests"
+    default: 0
+
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -444,6 +444,7 @@ rate_limiter:
   reset_interval_in_minutes: <%= p("cc.rate_limiter.reset_interval_in_minutes") %>
 
 <%
+max_concurrent_service_broker_requests: p("cc.max_concurrent_service_broker_requests")
 cc_uploader_url = nil
 if_link("cc_uploader") do |cc_uploader|
   cc_uploader_url = "https://#{cc_uploader.p("internal_hostname")}:#{cc_uploader.p("https_port")}"


### PR DESCRIPTION
## A short explanation of the proposed change:
Add configuration for service broker rate limiting

## An explanation of the use cases your change solves
Allow operators to limit how many concurrent service broker requests a user can make per broker

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2563

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
