### PR TITLE
Fix broken concurrent requests config

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -442,7 +442,8 @@ rate_limiter:
   global_unauthenticated_limit: <%= p("cc.rate_limiter.unauthenticated_limit") %>
   per_process_unauthenticated_limit: <%= (p("cc.rate_limiter.unauthenticated_limit").to_f/instances).ceil %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter.reset_interval_in_minutes") %>
-  max_concurrent_service_broker_requests: <%= p("cc.max_concurrent_service_broker_requests") %>
+
+max_concurrent_service_broker_requests: <%= p("cc.max_concurrent_service_broker_requests") %>
 
 <%
 cc_uploader_url = nil


### PR DESCRIPTION
I originally forgot some templating syntax and the fix bumped this into
the rate_limiting object but it is actually a root config option (since
it doesn't really apply to the classic rate limiting)
