### PR TITLE
Put libpq/bin directory on PATH

### DIFF
--- a/packages/cloud_controller_ng/packaging
+++ b/packages/cloud_controller_ng/packaging
@@ -7,6 +7,7 @@ cd ${BOSH_INSTALL_TARGET}/cloud_controller_ng
 
 mariadb_dir=/var/vcap/packages/mariadb_connector_c
 libpq_dir=/var/vcap/packages/libpq
+export PATH=$libpq_dir/bin:$PATH
 
 bundle config build.pg --with-pg-lib=$libpq_dir/lib --with-pg-include=$libpq_dir/include
 bundle config build.mysql2 --with-mysql-config=$mariadb_dir/bin/mariadb_config


### PR DESCRIPTION


## A short explanation of the proposed change
Add `libpq/bin` directory to path

## An explanation of the use cases your change solves
The libpq/bin directory contains pg_config which pg_sequel calls out to when compiling the C extension

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2595

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite

* [x] I have built and deployed this to a full BOSH environment and run it for a while without seeing any errors
