### PR TITLE
Introduces exponential backoff config parameter

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -810,6 +810,10 @@ properties:
     default: 10080
     description: "The max duration the CC will fetch service instance state from a service broker (in minutes). Default is 1 week"
 
+  cc.broker_client_async_poll_exponential_backoff_rate:
+    default: 1.0
+    description: "Exponential backoff for service related polling jobs. Default is 1.0, which means there is no exponential backoff."
+
   cc.development_mode:
     default: false
     description: "Enable development features for monitoring and insight"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -377,6 +377,7 @@ disable_custom_buildpacks: <%= p("cc.disable_custom_buildpacks") %>
 broker_client_timeout_seconds: <%= p("cc.broker_client_timeout_seconds") %>
 broker_client_default_async_poll_interval_seconds: <%= p('cc.broker_client_default_async_poll_interval_seconds') %>
 broker_client_max_async_poll_duration_minutes: <%= p('cc.broker_client_max_async_poll_duration_minutes') %>
+broker_client_async_poll_exponential_backoff_rate:  <%= p('cc.broker_client_async_poll_exponential_backoff_rate') %>
 renderer:
   max_results_per_page: <%= p("cc.renderer.max_results_per_page") %>
   default_results_per_page: <%= p("cc.renderer.default_results_per_page") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -480,6 +480,10 @@ properties:
     default: 10080
     description: "The max duration the CC will fetch service instance state from a service broker. Default is 1 week"
 
+  cc.broker_client_async_poll_exponential_backoff_rate:
+    default: 1.0
+    description: "Exponential backoff for service related polling jobs. Default is 1.0, which means there is no exponential backoff."
+
   cc.bits_service.enabled:
     description: "Enable integration of the bits-service incubator (experimental)"
     default: false

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -257,6 +257,7 @@ disable_custom_buildpacks: <%= p("cc.disable_custom_buildpacks") %>
 broker_client_timeout_seconds: <%= p("cc.broker_client_timeout_seconds") %>
 broker_client_default_async_poll_interval_seconds: <%= p('cc.broker_client_default_async_poll_interval_seconds') %>
 broker_client_max_async_poll_duration_minutes: <%= p('cc.broker_client_max_async_poll_duration_minutes') %>
+broker_client_async_poll_exponential_backoff_rate:  <%= p('cc.broker_client_async_poll_exponential_backoff_rate') %>
 
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This PR makes the cloud_controller_ng parameter which is introduced in https://github.com/cloudfoundry/cloud_controller_ng/pull/2667 configurable.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
