### PR TITLE
Introduce optional job priorities parameter

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -86,6 +86,8 @@ properties:
   cc.jobs.diego_sync.timeout_in_seconds:
     description: "The longest the diego sync job can take before another is enqueued"
     default: 600
+  cc.jobs.priorities:
+    description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
 
   cc.max_retained_deployments_per_app:
     description: "The number of inactive deployments to keep for each app"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -59,6 +59,9 @@ jobs:
   diego_sync:
     timeout_in_seconds: <%= timeout %>
   <% end %>
+  <% if_p("cc.jobs.priorities") do |priorities| %>
+  priorities: <%= priorities.to_json %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -373,6 +373,8 @@ properties:
     description: "The longest this job can take before it is cancelled"
   cc.jobs.droplet_upload.timeout_in_seconds:
     description: "The longest this job can take before it is cancelled"
+  cc.jobs.priorities:
+    description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
 
   cc.temporary_disable_deployments:
     description: "Do not allow the API client to create app deployments (temporary)"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -85,6 +85,9 @@ jobs:
   droplet_upload:
     timeout_in_seconds: <%= timeout %>
   <% end %>
+  <% if_p("cc.jobs.priorities") do |priorities| %>
+  priorities: <%= priorities.to_json %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -138,6 +138,8 @@ properties:
   cc.maximum_health_check_timeout:
     default: 180
     description: "Maximum health check timeout (in seconds) that can be set for the app"
+  cc.jobs.priorities:
+    description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
 
   cc.stacks:
     default:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -50,6 +50,9 @@ jobs:
   blobstore_delete:
     timeout_in_seconds: <%= timeout %>
   <% end %>
+  <% if_p("cc.jobs.priorities") do |priorities| %>
+  priorities: <%= priorities.to_json %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -391,6 +391,27 @@ module Bosh::Template::Test
 
       end
 
+      describe 'job priorities' do
+        it 'does not include priorities by default' do
+          template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+          expect(template_hash['jobs']).not_to include('priorities')
+        end
+
+        context 'when specified' do
+          it 'correctly renders priorities' do
+            merged_manifest_properties['cc']['jobs'] = {
+              'priorities' => {
+                'super.important.job' => -10,
+                'not-so-important-job' => 10
+              }
+            }
+            template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            expect(template_hash['jobs']['priorities']['super.important.job']).to eq(-10)
+            expect(template_hash['jobs']['priorities']['not-so-important-job']).to eq(10)
+          end
+        end
+      end
+
       context 'when rate limiting is enabled' do
         let(:self_link) do
           Link.new(name: 'cloud_controller', instances: [LinkInstance.new(address: '0.capi.service.internal')])


### PR DESCRIPTION
* A short explanation of the proposed change:
  This change allows operator to set the `cc.jobs.priorities` parameter introduced with this [ccng PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/2693).
   

* An explanation of the use cases your change solves
  As a platform operator I want to prioritize e.g. CF-Push over create service operations via an ops file.

* Links to any other associated PRs
   - Depends on https://github.com/cloudfoundry/cloud_controller_ng/pull/2693

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
