### PR TITLE
Provide means to disable telemetry logging

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1017,6 +1017,10 @@ properties:
     description: "Enable logging of all requests made to the Cloud Controller in CEF format."
     default: false
 
+  cc.telemetry_logging_enabled:
+    description: "Enable telemetry logging."
+    default: true
+
   cc.volume_services_enabled:
     description: "Enable binding to services that provide volume_mount information."
     default: false

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -138,7 +138,9 @@ logging:
   format:
     timestamp: <%= p("cc.logging.format.timestamp") %>
 
+<% if p("cc.telemetry_logging_enabled") %>
 telemetry_log_path: /var/vcap/sys/log/cloud_controller_ng/telemetry.log
+<% end %>
 
 logcache:
   host: <%= p("cc.logcache.host") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -201,7 +201,6 @@ module Bosh::Template::Test
         end
       end
 
-
       describe 'temporary_istio_domains' do
         context 'when an entry is an array of domains' do
           before do
@@ -408,6 +407,24 @@ module Bosh::Template::Test
             template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
             expect(template_hash['jobs']['priorities']['super.important.job']).to eq(-10)
             expect(template_hash['jobs']['priorities']['not-so-important-job']).to eq(10)
+          end
+        end
+      end
+
+      describe 'telemetry logging' do
+        it 'configures the default telemetry_log_path' do
+          template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+          expect(template_hash['telemetry_log_path']).to eq('/var/vcap/sys/log/cloud_controller_ng/telemetry.log')
+        end
+
+        context 'when disabled' do
+          before do
+            merged_manifest_properties['cc']['telemetry_logging_enabled'] = false
+          end
+
+          it 'omits the telemetry_log_path' do
+            template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+            expect(template_hash['telemetry_log_path']).to be_nil
           end
         end
       end


### PR DESCRIPTION
`/var/vcap/sys/log/cloud_controller_ng/telemetry.log` was the hard-coded value of the `telemetry_log_path`. When setting the new config option `cc.telemetry_logging_enabled` to `false` (default value is `true`), `telemetry_log_path` will be omitted.

Requires cloudfoundry/cloud_controller_ng#2744

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
