### PR TITLE
Use post_bbr_healthcheck_timeout_in_seconds for backup and restore

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -350,6 +350,10 @@ properties:
     default: 60
     description: "Maximum time (in seconds) for cloud_controller_ng to report healthy"
 
+  cc.post_bbr_healthcheck_timeout_in_seconds:
+    default: 60
+    description: "Maximum time (in seconds) for cloud_controller_ng to report healthy in backup and restore unlock"
+
   cc.api_health_check_timeout_per_retry:
     default: 2
     description: "Maximum health check timeout (in seconds) for each retry attempt in the Cloud Controller's route registration health check"

--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -14,7 +14,7 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   fi
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.api_post_start_healthcheck_timeout_in_seconds") %>
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
   sleep 30
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>

--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -14,7 +14,7 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   fi
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> 60
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.api_post_start_healthcheck_timeout_in_seconds") %>
   sleep 30
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>

--- a/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
@@ -14,7 +14,7 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   fi
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.api_post_start_healthcheck_timeout_in_seconds") %>
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
   sleep 30
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>

--- a/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-restore-unlock.sh.erb
@@ -14,7 +14,7 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   fi
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> 60
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.api_post_start_healthcheck_timeout_in_seconds") %>
   sleep 30
 
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>


### PR DESCRIPTION
unlock

- post-start waits for server to become healthy with
  api_post_start_healthcheck_timeout_in_seconds, so consistent now
  across post-backup and post-restore
- still uses default of 60 seconds
- user can expect the same time now

Authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
