### PR TITLE
Add bionic nfs blobs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,22 @@ nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: a7207ad8-8660-4e0d-72a1-7fdd605e131d
   sha: sha256:782865f7688ecc2a168f6c51e8e63f44326d73144a9df35087fd1e55e30d23db
+nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
+  size: 47896
+  object_id: 7ec8f95e-80a7-47f5-61aa-39170aefa1f7
+  sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
 nfs-debs/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb:
   size: 114014
   object_id: 14622888-be2d-413e-4133-874bfe135968
   sha: sha256:e1acdffde386a4da7de46166ffd199771a13498f5d4fc38d61b3fa0eba305572
+nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
+  size: 133328
+  object_id: 79b7896d-e0e9-44df-485a-82dd91b57321
+  sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
+nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb:
+  size: 27180
+  object_id: b72f3c09-f9ea-48bb-45ef-fd3c3de32348
+  sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
 nfs-debs/libnfsidmap2_0.25-5_amd64.deb:
   size: 32182
   object_id: 08d519cb-e173-4652-406f-b0c23e694671
@@ -22,10 +34,18 @@ nfs-debs/nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb:
   size: 184334
   object_id: b6012af0-4414-4a53-7a80-8b143fe03ada
   sha: sha256:91ee605b09bd024ed97338bed442285c5980810d9a94f23aa182255e1c16316b
+nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb:
+  size: 205520
+  object_id: 4383380e-5ab5-4b88-7262-a02025370122
+  sha: sha256:ecf4d9601d210d86d423457dd18a7d3af406ed34a273fb22ade431764fc66d67
 nfs-debs/rpcbind_0.2.3-0.2_amd64.deb:
   size: 40252
   object_id: 7f2f0cb1-6ca8-4524-44f7-30cf31a6d72e
   sha: sha256:7c9d1aca35cd01ef0c9cbc90f93e993116e84de1967c429e1130a16281fd3a6e
+nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
+  size: 42124
+  object_id: 3d7b5940-a1b8-4780-7c73-14c74163f202
+  sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
 nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   size: 5222
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d

--- a/jobs/nfs_mounter/templates/pre-start.sh.erb
+++ b/jobs/nfs_mounter/templates/pre-start.sh.erb
@@ -16,7 +16,7 @@ install_if_missing ()
     fi
 }
 
-codename=$(lsb_release -c | grep xenial | awk '{print $2}')
+codename=$(lsb_release -cs)
 if [ "$codename" == "xenial" ]; then
     echo "Installing NFS packages"
     (
@@ -26,5 +26,15 @@ if [ "$codename" == "xenial" ]; then
     install_if_missing libevent-2.0-5 /var/vcap/packages/nfs-debs/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb
     install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5_amd64.deb
     install_if_missing nfs-common /var/vcap/packages/nfs-debs/nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb
+    ) 200>/var/vcap/data/dpkg.lock
+elif [ "$codename" == "bionic" ]; then
+    echo "Installing NFS packages"
+    (
+    flock -x 200
+    install_if_missing rpcbind /var/vcap/packages/nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
+    install_if_missing keyutils /var/vcap/packages/nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb
+    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
+    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb
+    install_if_missing nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb
     ) 200>/var/vcap/data/dpkg.lock
 fi

--- a/packages/nfs-debs/README.md
+++ b/packages/nfs-debs/README.md
@@ -7,7 +7,18 @@ They can be downloaded from the following locations:
 | Filename | Download URL |
 | -------- | ------------ |
 | keyutils_1.5.9-8ubuntu1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.5.9-8ubuntu1_amd64.deb |
+| keyutils_1.5.9-9.2ubuntu2_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.5.9-9.2ubuntu2_amd64.deb |
 | libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb|
+| libevent-2.1-6_2.1.8-stable-4build1_amd64.deb |
+http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
+|
 | libnfsidmap2_0.25-5_amd64.deb | http://ftp.ussg.iu.edu/linux/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5_amd64.deb |
+| libnfsidmap2_0.25-5.1_amd64.deb |
+http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1_amd64.deb
+|
 | nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/n/nfs-utils/nfs-common_1.2.8-9ubuntu12.1_amd64.deb |
+| nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb | http://security.ubuntu.com/ubuntu/pool/main/n/nfs-utils/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb |
 | rpcbind_0.2.3-0.2_amd64.deb | http://mirrors.cat.pdx.edu/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.2_amd64.deb |
+| rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb |
+http://security.ubuntu.com/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
+|

--- a/packages/nfs-debs/README.md
+++ b/packages/nfs-debs/README.md
@@ -9,16 +9,10 @@ They can be downloaded from the following locations:
 | keyutils_1.5.9-8ubuntu1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.5.9-8ubuntu1_amd64.deb |
 | keyutils_1.5.9-9.2ubuntu2_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.5.9-9.2ubuntu2_amd64.deb |
 | libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb|
-| libevent-2.1-6_2.1.8-stable-4build1_amd64.deb |
-http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
-|
+| libevent-2.1-6_2.1.8-stable-4build1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb |
 | libnfsidmap2_0.25-5_amd64.deb | http://ftp.ussg.iu.edu/linux/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5_amd64.deb |
-| libnfsidmap2_0.25-5.1_amd64.deb |
-http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1_amd64.deb
-|
+| libnfsidmap2_0.25-5.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1_amd64.deb |
 | nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/n/nfs-utils/nfs-common_1.2.8-9ubuntu12.1_amd64.deb |
 | nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb | http://security.ubuntu.com/ubuntu/pool/main/n/nfs-utils/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb |
 | rpcbind_0.2.3-0.2_amd64.deb | http://mirrors.cat.pdx.edu/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.2_amd64.deb |
-| rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb |
-http://security.ubuntu.com/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
-|
+| rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb | http://security.ubuntu.com/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb |

--- a/packages/nfs-debs/spec
+++ b/packages/nfs-debs/spec
@@ -3,7 +3,12 @@ name: nfs-debs
 
 files:
   - nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb
+  - nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb
   - nfs-debs/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb
+  - nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
   - nfs-debs/libnfsidmap2_0.25-5_amd64.deb
+  - nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb
   - nfs-debs/nfs-common_1%3a1.2.8-9ubuntu12.1_amd64.deb
+  - nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb
   - nfs-debs/rpcbind_0.2.3-0.2_amd64.deb
+  - nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb


### PR DESCRIPTION
- bionic stemcells are released and this adds nfs-common and its
dependencies for bionic

Authored-by: Michael Oleske <moleske@pivotal.io>

This fixes the ripley environment and we can unpause the pipeline after merging this

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on ~~bosh lite~~ ripley
