### PR TITLE
Adds health check script for Bosh DNS

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -7,6 +7,7 @@ templates:
   bin/cloud_controller_ng.erb: bin/cloud_controller_ng
   bin/local_worker.erb: bin/local_worker
   bin/nginx_newrelic_plugin.erb: bin/nginx_newrelic_plugin
+  bin/dns/healthy.sh.erb: bin/dns/healthy
   bpm.yml.erb: config/bpm.yml
   pre-backup-lock.sh.erb: bin/bbr/pre-backup-lock
   post-backup-unlock.sh.erb: bin/bbr/post-backup-unlock

--- a/jobs/cloud_controller_ng/templates/bin/dns/healthy.sh.erb
+++ b/jobs/cloud_controller_ng/templates/bin/dns/healthy.sh.erb
@@ -1,0 +1,1 @@
+../../cloud_controller_api_health_check.erb


### PR DESCRIPTION
This commit resolves the core problem in the CC-112 Jira ticket. It
-effectively- instructs Bosh DNS to run the same Cloud Controller health
checking script that `route-registrar` uses to decide whether CCNG's
route should be removed or reinstated in Gorouter.

Because these two health check scripts are run by two separate
components, each with their own start time, and each with its own
frequency with which it will collect and report health check
information, there will inevitably be gaps between the time CCNG is
reported as unhealthy in one system and it is reported as unhealthy in
the other. This seems to be unavoidable.

Co-authored-by: David Alvarado <alvaradoda@vmware.com>
Co-authored-by: Kenneth Lakin <klakin@vmware.com>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite

We have not run CATS, but have proven that this works on a full TAS (Formerly Known as "Pivotal Cloud Foundry") deployment.