### PR TITLE
Use OpenSSL 3.0-compatible nginx

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -51,9 +51,9 @@ nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d
   sha: sha256:a5a7f9b3a7e20302943b1dd448d9b725cf3cb28d774d79f618aab7c4ddeea52b
 nginx/nginx-1.21.6.tar.gz:
-  size: 1061461
-  object_id: 514c0a64-b27d-4eb9-783f-3ea15b2003e1
-  sha: sha256:e462e11533d5c30baa05df7652160ff5979591d291736cfa5edb9fd2edb48c49
+  size: 1073364
+  object_id: 70f0dcea-e96a-4522-4a6c-588d551b7397
+  sha: sha256:66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae
 nginx/nginx-dav-ext-module-3.0.0.tar.gz:
   size: 14558
   object_id: 44648d53-c24b-45e4-4434-007713aa5fe7

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -50,7 +50,7 @@ nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   size: 5222
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d
   sha: sha256:a5a7f9b3a7e20302943b1dd448d9b725cf3cb28d774d79f618aab7c4ddeea52b
-nginx/nginx-1.20.1.tar.gz:
+nginx/nginx-1.21.6.tar.gz:
   size: 1061461
   object_id: 514c0a64-b27d-4eb9-783f-3ea15b2003e1
   sha: sha256:e462e11533d5c30baa05df7652160ff5979591d291736cfa5edb9fd2edb48c49

--- a/packages/nginx/README.md
+++ b/packages/nginx/README.md
@@ -6,6 +6,6 @@ The files can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| nginx-1.20.1.tar.gz | [nginx.org](http://nginx.org/download/nginx-1.20.1.tar.gz) |
+| nginx-1.21.6.tar.gz | [nginx.org](http://nginx.org/download/nginx-1.21.6.tar.gz) |
 | nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz)
 | pcre-8.45.tar.gz | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz) |

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -13,10 +13,10 @@ pushd nginx-upload-module-2.3.0
 popd
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.20.1.tar.gz
+tar xzvf nginx/nginx-1.21.6.tar.gz
 
 echo "Building nginx..."
-pushd nginx-1.20.1
+pushd nginx-1.21.6
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.45 \

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -1,7 +1,7 @@
 ---
 name: nginx
 files:
-- nginx/nginx-1.20.1.tar.gz
+- nginx/nginx-1.21.6.tar.gz
 - nginx/pcre-8.45.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -15,13 +15,13 @@ echo "Extracting pcre..."
 tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.20.1.tar.gz
+tar xzvf nginx/nginx-1.21.6.tar.gz
 
 echo "Extracting webdav extensions"
 tar xzvf nginx/nginx-dav-ext-module-3.0.0.tar.gz
 
 echo "Building nginx..."
-pushd nginx-1.20.1
+pushd nginx-1.21.6
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -2,6 +2,6 @@
 name: nginx_webdav
 files:
   - expat/expat-2.3.0.tar.bz2
-  - nginx/nginx-1.20.1.tar.gz
+  - nginx/nginx-1.21.6.tar.gz
   - nginx/pcre-8.45.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz


### PR DESCRIPTION
The current nginx is not compatible with OpenSSL 3.0, causing compilation failures on the upcoming Jammy Jellyfish-based stemcells.

This commit fixes that by bumping nginx 1.20.1 → 1.21.6.

Fixes, during compilation phase:
```
Task 63223 | 13:39:29 | Compiling packages: nginx_webdav/... (00:02:48)
In file included from src/event/ngx_event_openssl.h:22,
                 from src/core/ngx_core.h:84,
                 from src/event/ngx_event_openssl.c:9:
/usr/include/openssl/engine.h:493:27: note: declared here
  493 | OSSL_DEPRECATEDIN_3_0 int ENGINE_free(ENGINE *e);
      |                           ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:857: objs/src/event/ngx_event_openssl.o] Error 1
make: *** [Makefile:10: build] Error 2
```

### You Must do the Following

(I'd do it myself, except I don't have creds to the blobstore):

```bash
 # Download the nginx blob
pushd ~/Downloads
curl -OL http://nginx.org/download/nginx-1.21.6.tar.gz
popd
 # Verify the downloaded nginx
pushd /tmp/
curl -OL http://nginx.org/download/nginx-1.21.6.tar.gz.asc
curl -OL https://nginx.org/keys/mdounin.key
popd
gpg --import /tmp/mdounin.key
gpg --verify /tmp/nginx-1.21.6.tar.gz.asc ~/Downloads/nginx-1.21.6.tar.gz
# look for “Good signature from "Maxim Dounin <mdounin@mdounin.ru>"; ignore hysterical warning about key not certified
 # Let's add the new blob to the BOSH release & remove the outdated one
cd ~/workspace/capi-release
bosh remove-blob \
  nginx/nginx-1.20.1.tar.gz
bosh add-blob \
  ~/Downloads/nginx-1.21.6.tar.gz \
  nginx/nginx-1.21.6.tar.gz
# ...then proceed to create a new release
```

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

We bump nginx in order to bring in a version which is compatible with OpenSSL 3 which is the version that's included in the Jammy Jellyfish-based stemcells.

* An explanation of the use cases your change solves

This is one of several changes needed to allow CAPI release to be deployed on Jammy. Specifically, this release allows the singleton-blobstore instance group to be deployed on Jammy

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on ~~bosh lite~~ vSphere

I have run CF Acceptance on this PR twice (both passed without errors):
- on a hybrid Jammy+Bionic deployment
- on a Xenial 621.249-based environment.