### PR TITLE
Use OpenSSL 3.0-compatible mariadb connector

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ expat/expat-2.3.0.tar.bz2:
   size: 533513
   object_id: 20689f9c-8d1a-464f-54eb-5386806cfd47
   sha: sha256:f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586
-mariadb_connector_c/mariadb-connector-c-2.3.5-src.tar.gz:
-  size: 540018
-  object_id: 27f389e6-85e6-47c3-4c60-256dd7d9874d
-  sha: sha256:2f3bf4c326d74284debf7099f30cf3615f7978d1ec22b8c1083676688a76746f
+mariadb_connector_c/mariadb-connector-c-3.3.1-src.tar.gz:
+  size: 1376983
+  object_id: da707aa5-a7a0-446a-77c6-d9810fc5abf1
+  sha: sha256:29993f4ae4c975662724978792d1a503b9ee760fbb194d321a754253cbe60aad
 nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: a7207ad8-8660-4e0d-72a1-7fdd605e131d

--- a/packages/mariadb_connector_c/README.md
+++ b/packages/mariadb_connector_c/README.md
@@ -6,4 +6,4 @@ This file can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| mariadb-connector-c-2.3.5-src.tar.gz | https://downloads.mariadb.org/interstitial/connector-c-2.3.5/mariadb-connector-c-2.3.5-src.tar.gz |
+| mariadb-connector-c-3.3.1-src.tar.gz | https://dlm.mariadb.com/2319728/Connectors/c/connector-c-3.3.1/mariadb-connector-c-3.3.1-src.tar.gz |

--- a/packages/mariadb_connector_c/packaging
+++ b/packages/mariadb_connector_c/packaging
@@ -1,6 +1,6 @@
 set -e -x
 
-VERSION=2.3.5
+VERSION=3.3.1
 
 tar xzf mariadb_connector_c/mariadb-connector-c-${VERSION}-src.tar.gz
 

--- a/packages/mariadb_connector_c/spec
+++ b/packages/mariadb_connector_c/spec
@@ -1,4 +1,4 @@
 ---
 name: mariadb_connector_c
 files:
-- mariadb_connector_c/mariadb-connector-c-2.3.5-src.tar.gz
+- mariadb_connector_c/mariadb-connector-c-3.3.1-src.tar.gz


### PR DESCRIPTION
The current mariadb connector c is not compatible with OpenSSL 3.0, causing compilation failures on the upcoming Jammy Jellyfish-based stemcells.

This commit fixes that by bumping mariadb connector c 2.3.5 → 3.3.1

Error that it fixes:
```
Task 63221 | 13:27:45 | Compiling packages: mariadb_connector_c/214543bbb1d7499acdbdb44a7323430a635a77fa004f4fd4dbaf4e544291b072 (00:03:05)
CMake Error at cmake/ConnectorName.cmake:30 (ENDMACRO):
  Flow control statements are not properly nested.
nginx/3f524e8d016595416a9ad5dac6bb9490a0eb765a85c76c47635b447184ef691d (00:03:25)
```

Co-authored-by: Brian Cunnie <bcunnie@vmware.com>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This PR bumps the MariaDB Connector C version.

* An explanation of the use cases your change solves

The current version of MariaDB Connector C fails to compile on Jammy Jellyfish-based stemcells.

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on ~~bosh lite~~ vSphere

And the tests passed, too!
