### PR TITLE
Add configuration for v2 API rate limiter

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1066,6 +1066,19 @@ properties:
     description: "Maximum number of concurrent requests to service brokers per user. Set to 0 to not limit concurrent requests"
     default: 0
 
+  cc.rate_limiter_v2_api.enabled:
+    description: "Enable rate limiting for UAA-authenticated V2 API (v2/*, except v2/info) endpoints per user or client"
+    default: false
+  cc.rate_limiter_v2_api.general_limit:
+    description: "The number of requests a user or client is allowed to make for v2/* endpoints that do not have a custom limit over the configured interval"
+    default: 2000
+  cc.rate_limiter_v2_api.admin_limit:
+    description: "The number of requests an admin user or client is allowed to make for v2/* endpoints over the configured interval"
+    default: 2000
+  cc.rate_limiter_v2_api.reset_interval_in_minutes:
+    description: "The interval in minutes after which a user's available V2 API requests will be reset"
+    default: 60
+
   cc.diego.bbs.url:
     description: "URL of the BBS Server"
     default: https://bbs.service.cf.internal:8889

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -451,6 +451,15 @@ rate_limiter:
 
 max_concurrent_service_broker_requests: <%= p("cc.max_concurrent_service_broker_requests") %>
 
+<% instances = p("cc.rate_limiter_v2_api.enabled") ? link("cloud_controller").instances.length : 1 %>
+rate_limiter_v2_api:
+  enabled: <%= p("cc.rate_limiter_v2_api.enabled") %>
+  global_general_limit: <%= p("cc.rate_limiter_v2_api.general_limit") %>
+  per_process_general_limit: <%= (p("cc.rate_limiter_v2_api.general_limit").to_f/instances).ceil %>
+  global_admin_limit: <%= p("cc.rate_limiter_v2_api.admin_limit") %>
+  per_process_admin_limit: <%= (p("cc.rate_limiter_v2_api.admin_limit").to_f/instances).ceil %>
+  reset_interval_in_minutes: <%= p("cc.rate_limiter_v2_api.reset_interval_in_minutes") %>
+
 <%
 cc_uploader_url = nil
 if_link("cc_uploader") do |cc_uploader|


### PR DESCRIPTION
* A short explanation of the proposed change:
  Add configuration for the v2 API rate limiter. It calculates the `per_process` limit based on the number of instances similar to the general rate limiter. More details about the v2 rate limiter can be found in https://github.com/cloudfoundry/cloud_controller_ng/pull/2882

* An explanation of the use cases your change solves
  As an operator I want to enable/configure the rate limit v2 API calls for regular (incl. unauthenticated) and admin users

* Links to any other associated PRs
  - https://github.com/cloudfoundry/cloud_controller_ng/pull/2882

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
