### PR TITLE
nfs-common now depends on libevent-core, not libevent

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -26,10 +26,10 @@ nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
   size: 133328
   object_id: 79b7896d-e0e9-44df-485a-82dd91b57321
   sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
-nfs-debs/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb:
-  size: 148238
-  object_id: f0d0ee58-b6ec-4086-4889-2f526fc50d1e
-  sha: sha256:e13aac87e4143293cf1d3cb82a2458fbeacc234d0db0667fd5567bdcd6da15fe
+nfs-debs/libevent-core-2.1-7_2.1.12-stable-1build3_amd64.deb:
+  size: 93926
+  object_id: e32166c6-cdd5-4adc-6b59-16eb5c9a2224
+  sha: sha256:9317ae74915b9e4372f7506fbd16ae2a021e0ead79a8d88f96dad49b87d94508
 nfs-debs/libnfsidmap1_2.6.1-1ubuntu1_amd64.deb:
   size: 43534
   object_id: ee3548ea-d65b-44a3-5d9e-89aedd8fbc63

--- a/packages/nfs-debs/README.md
+++ b/packages/nfs-debs/README.md
@@ -11,7 +11,7 @@ They can be downloaded from the following locations:
 | keyutils_1.6.1-2ubuntu3_amd64.deb | Jammy | http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.6.1-2ubuntu3_amd64.deb |
 | libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb|
 | libevent-2.1-6_2.1.8-stable-4build1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb |
-| libevent-2.1-7_2.1.12-stable-1build3_amd64.deb | Jammy | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb |
+| libevent-core-2.1-7_2.1.12-stable-1build3_amd64.deb | Jammy | http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-core-2.1-7_2.1.12-stable-1build3_amd64.deb |
 | libnfsidmap2_0.25-5_amd64.deb | http://ftp.ussg.iu.edu/linux/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5_amd64.deb |
 | libnfsidmap2_0.25-5.1_amd64.deb | http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1_amd64.deb |
 | libnfsidmap1_2.6.1-1ubuntu1_amd64.deb | Jammy | http://mirrors.kernel.org/ubuntu/pool/main/n/nfs-utils/libnfsidmap1_2.6.1-1ubuntu1_amd64.deb |

--- a/packages/nfs-debs/spec
+++ b/packages/nfs-debs/spec
@@ -7,7 +7,7 @@ files:
   - nfs-debs/keyutils_1.6.1-2ubuntu3_amd64.deb
   - nfs-debs/libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb
   - nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
-  - nfs-debs/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb
+  - nfs-debs/libevent-core-2.1-7_2.1.12-stable-1build3_amd64.deb
   - nfs-debs/libnfsidmap2_0.25-5_amd64.deb
   - nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb
   - nfs-debs/libnfsidmap1_2.6.1-1ubuntu1_amd64.deb


### PR DESCRIPTION
Authored-by: Seth Boyles <sboyles@pivotal.io>

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
