### PR TITLE
Set 'RAILS_ENV' to `production`

### DIFF
--- a/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -15,6 +15,7 @@ config = { "processes" => [] }
       "NEW_RELIC_ENV" => "#{p("cc.newrelic.environment_name")}_background",
       "NEW_RELIC_DISPATCHER" => "delayed_job",
       "NRCONFIG" => "/var/vcap/jobs/cloud_controller_worker/config/newrelic.yml",
+      "RAILS_ENV" => "production",
       "INDEX" => index
     }
   }


### PR DESCRIPTION
`RAILS_ENV` should be set  to `production` to prevent rails/active support from reloading routes. In context of a cc worker this feature is not needed because there are no routes.

Related to #262

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
