### PR TITLE
Revert "Introduce experimental use_optimized_json_encoder configurati…

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1223,10 +1223,6 @@ properties:
     description: "How many threads a single cloud controller instance's thin server will attempt to use. Alter at your own peril."
     default: 20 # inherited from default in Thin/EventMachine
 
-  cc.experimental.use_optimized_json_encoder:
-    description: "Switch to a different Ruby JSON encoder, i.e. Oj (https://github.com/ohler55/oj)."
-    default: false
-
   cc.kubernetes.host_url:
     description: "Kubernetes master API URL"
   cc.kubernetes.service_account.name:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -536,8 +536,6 @@ internal_route_vip_range: <%= internal_vip_range %>
 
 threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>
 
-use_optimized_json_encoder: <%= p("cc.experimental.use_optimized_json_encoder") %>
-
 <% if_p("cc.kubernetes.host_url") do %>
 kubernetes:
   host_url: <%= p("cc.kubernetes.host_url") %>


### PR DESCRIPTION
…on (#208)"

This reverts commit 28d6e39eae10477753fbf8a70fe69a7380075269.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
remove experimental use optimized json encoder as it will be the only one

* An explanation of the use cases your change solves

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2930 would need to be merged at the same time as that actually removed usage of it

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
