### PR TITLE
Log rate limit changes

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -467,6 +467,10 @@ properties:
     description: "The file descriptors made available to each app instance"
     default: 16384
 
+  cc.default_app_log_rate_limit_in_bytes_per_second:
+    default: 9999
+    description: "Default application log rate limit"
+
   cc.bits_service.enabled:
     description: "Enable integration of the bits-service incubator (experimental)"
     default: false

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -468,7 +468,7 @@ properties:
     default: 16384
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 9999
+    default: 16384
     description: "Default application log rate limit"
 
   cc.bits_service.enabled:

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -468,7 +468,7 @@ properties:
     default: 16384
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 16384
+    default: -1
     description: "Default application log rate limit"
 
   cc.bits_service.enabled:

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -70,6 +70,8 @@ max_retained_deployments_per_app: <%= p("cc.max_retained_deployments_per_app") %
 max_retained_builds_per_app: <%= p("cc.max_retained_builds_per_app") %>
 max_retained_revisions_per_app: <%= p("cc.max_retained_revisions_per_app") %>
 
+default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
+
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 
 app_usage_events:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -381,10 +381,6 @@ properties:
     description: "Do not allow the API client to create app deployments (temporary)"
     default: false
 
-  cc.temporary_use_logcache:
-    description: "Use logcache instead of Traffic Controller for retrieving container metrics"
-    default: false
-
   cc.temporary_enable_v2:
     description: "Enable V2 endpoints"
     default: true
@@ -796,6 +792,10 @@ properties:
   cc.app_bits_max_body_size:
     default: "1536M"
     description: "Maximum body size for nginx bits uploads"
+
+  cc.default_app_log_rate_limit_in_bytes_per_second:
+    default: 9999
+    description: "Default application log rate limit"
 
   cc.disable_custom_buildpacks:
     default: false

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -794,7 +794,7 @@ properties:
     description: "Maximum body size for nginx bits uploads"
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 9999
+    default: 16384
     description: "Default application log rate limit"
 
   cc.disable_custom_buildpacks:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -794,7 +794,7 @@ properties:
     description: "Maximum body size for nginx bits uploads"
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 16384
+    default: -1
     description: "Default application log rate limit"
 
   cc.disable_custom_buildpacks:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -61,7 +61,6 @@ development_mode: <%= p("cc.development_mode") %>
 external_protocol: <%= p("cc.external_protocol") %>
 external_domain: <%= p("cc.external_host") %>.<%= p("system_domain") %>
 temporary_disable_deployments: <%= p("cc.temporary_disable_deployments") %>
-temporary_use_logcache: <%= p("cc.temporary_use_logcache") %>
 
 system_domain_organization: <%= p("system_domain_organization") %>
 system_domain: <%= p("system_domain") %>
@@ -92,6 +91,8 @@ jobs:
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
+
+default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -459,6 +459,10 @@ properties:
     description: "The file descriptors made available to each app instance"
     default: 16384
 
+  cc.default_app_log_rate_limit_in_bytes_per_second:
+    default: 9999
+    description: "Default application log rate limit"
+
   cc.thresholds.worker.alert_if_above_mb:
     description: "The CC will alert if memory remains above this threshold for 3 monit cycles"
     default: 384

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -460,7 +460,7 @@ properties:
     default: 16384
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 16384
+    default: -1
     description: "Default application log rate limit"
 
   cc.thresholds.worker.alert_if_above_mb:

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -460,7 +460,7 @@ properties:
     default: 16384
 
   cc.default_app_log_rate_limit_in_bytes_per_second:
-    default: 9999
+    default: 16384
     description: "Default application log rate limit"
 
   cc.thresholds.worker.alert_if_above_mb:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -60,6 +60,8 @@ maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 
+default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
+
 internal_api:
   auth_user: <%= p("cc.internal_api_user") %>
   auth_password: <%= yaml_escape(p("cc.internal_api_password")) %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
- add a default rate limit to capi

- Remove cc.temporary_use_logcache property

    New cloud controllers don't support using Traffic Controller for
    container metrics, so removing this property from capi-release
* An explanation of the use cases your change solves
Capi release changes for cloud controller ng for log rate limiting feature
* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2900
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
