### PR TITLE
Update log_audit_events cloud controller property to true by default

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1200,7 +1200,7 @@ properties:
                   will need to be recreated."
 
   cc.log_audit_events:
-    default: false
+    default: true
     description: "Log audit events"
 
   copilot.enabled:


### PR DESCRIPTION
We are updating the functionality of this here: https://github.com/cloudfoundry/cloud_controller_ng/pull/2962 and we believe the new behavior should be on by default.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
