### PR TITLE
Add experimental flag to enable YJIT compiler

### DIFF
--- a/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
+++ b/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
@@ -2,4 +2,9 @@
 
 source /var/vcap/jobs/cc_deployment_updater/bin/ruby_version.sh
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
+
+<% if link("cloud_controller_internal").p('cc.experimental.use_yjit_compiler') %>
+export RUBYOPT='--yjit'
+<% end %>
+
 exec bundle exec rake deployment_updater:start

--- a/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
+++ b/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
@@ -2,4 +2,9 @@
 
 source /var/vcap/jobs/cloud_controller_clock/bin/ruby_version.sh
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
+
+<% if link("cloud_controller_internal").p('cc.experimental.use_yjit_compiler') %>
+export RUBYOPT='--yjit'
+<% end %>
+
 exec bundle exec rake clock:start

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -162,6 +162,7 @@ provides:
   - cc.external_host
   - cc.external_port
   - cc.external_protocol
+  - cc.experimental.use_yjit_compiler
   - cc.internal_service_hostname
   - cc.log_db_queries
   - cc.logging.format.timestamp
@@ -1222,7 +1223,9 @@ properties:
   cc.experimental.thin_server.thread_pool_size:
     description: "How many threads a single cloud controller instance's thin server will attempt to use. Alter at your own peril."
     default: 20 # inherited from default in Thin/EventMachine
-
+  cc.experimental.use_yjit_compiler:
+    description: "Use Ruby's YJIT compiler when running Cloud Controller API servers and workers. This feature is experimental and not recommended. Please review the drawbacks and benefits of YJIT before enabling."
+    default: false
   cc.kubernetes.host_url:
     description: "Kubernetes master API URL"
   cc.kubernetes.service_account.name:

--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -14,5 +14,9 @@ echo 'Running migrations and seeds'
 echo 'Finished migrations and seeds'
 <% end %>
 
+<% if p('cc.experimental.use_yjit_compiler') %>
+export RUBYOPT='--yjit'
+<% end %>
+
 exec /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller \
   -c /var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml

--- a/jobs/cloud_controller_ng/templates/bin/local_worker.erb
+++ b/jobs/cloud_controller_ng/templates/bin/local_worker.erb
@@ -5,5 +5,9 @@ source /var/vcap/jobs/cloud_controller_ng/bin/blobstore_waiter.sh
 
 wait_for_blobstore
 
+<% if p('cc.experimental.use_yjit_compiler') %>
+export RUBYOPT='--yjit'
+<% end %>
+
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 exec bundle exec rake "jobs:local[cc_api_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]"

--- a/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
+++ b/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
@@ -5,5 +5,10 @@ source /var/vcap/jobs/cloud_controller_worker/bin/blobstore_waiter.sh
 
 wait_for_blobstore
 
+<% if link("cloud_controller_internal").p('cc.experimental.use_yjit_compiler') %>
+export RUBYOPT='--yjit'
+<% end %>
+
+
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 exec bundle exec rake jobs:generic[cc_global_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]


### PR DESCRIPTION
enables YJIT compiler on CC jobs.

YJIT is optimized for long running processes, trading a higher memory usage for speed improvements. 

Most of the jobs worked fine without alteration with default config values, but I did have to bump up the memory thresholds on the cc-worker.

for more on running YJIT: 
https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md
https://news.ycombinator.com/item?id=29161810

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
