### PR TITLE
Add mariadb_config wrapper script to fix symlink paths

### DIFF
--- a/packages/cloud_controller_ng/packaging
+++ b/packages/cloud_controller_ng/packaging
@@ -10,5 +10,5 @@ libpq_dir=/var/vcap/packages/libpq
 export PATH=$libpq_dir/bin:$PATH
 
 bundle config build.pg --with-pg-lib=$libpq_dir/lib --with-pg-include=$libpq_dir/include
-bundle config build.mysql2 --with-mysql-config=$mariadb_dir/bin/mariadb_config
+bundle config build.mysql2 --with-mysql-config=$mariadb_dir/bin/mariadb_config-wrapper.sh
 bosh_bundle_local --deployment

--- a/packages/mariadb_connector_c/packaging
+++ b/packages/mariadb_connector_c/packaging
@@ -11,3 +11,5 @@ pushd mariadb-connector-c-${VERSION}-src > /dev/null
 	make
 	make install
 popd > /dev/null
+
+cp mariadb-customization/mariadb_config-wrapper.sh ${BOSH_INSTALL_TARGET}/bin/

--- a/packages/mariadb_connector_c/spec
+++ b/packages/mariadb_connector_c/spec
@@ -2,3 +2,4 @@
 name: mariadb_connector_c
 files:
 - mariadb_connector_c/mariadb-connector-c-3.3.1-src.tar.gz
+- mariadb-customization/*

--- a/src/mariadb-customization/mariadb_config-wrapper.sh
+++ b/src/mariadb-customization/mariadb_config-wrapper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [ -L /var/vcap/packages/mariadb_connector_c ]
+then
+  # After the upgrade to mariadb connector 3.x, the mariadb_config binary started returned dereferenced symlinks
+  # instead of the symlink paths. This breaks the mysql2 gem if you compile the director package on one VM, and then
+  # use it on another. No amount of flags (such as --with-mysql-include) seemed to fix the problem. Specifically, the
+  # rpaths of the mysql2.so are paths that no longer exist.
+  /var/vcap/packages/mariadb_connector_c/bin/mariadb_config "$@" |  sed -e "s@$(readlink /var/vcap/packages/mariadb_connector_c)/@/var/vcap/packages/mariadb_connector_c/@g"
+else
+  /var/vcap/packages/mariadb_connector_c/bin/mariadb_config "$@"
+fi
+


### PR DESCRIPTION
Upgrading from mariadb connector 2.x to 3.x the mariadb_config started returning absolute paths rather than relative paths to the mariadb package folders. These absolute paths change when exporting the release from one director to another.

There doesn't seem to be a set of flags we can manually pass to build the mysql2 gem so we were forced to add a wrapper script that replaces the absolute paths with the relative paths.

Mostly stolen from here: https://github.com/cloudfoundry/bosh/commit/5a9b68c2c9402943afd2bcc7a19aaf6437b9bbbf
