### PR TITLE
Add v5 endpoint for drain-controller to nginx.conf

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -77,6 +77,10 @@ http {
       proxy_pass http://cloud_controller;
     }
 
+    location /internal/v5/ {
+      proxy_pass http://cloud_controller;
+    }
+
     location ~ /internal/v3/staging/.*/(droplet_completed|build_completed) {
       proxy_pass http://cloud_controller;
     }

--- a/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
@@ -3,6 +3,10 @@ location /internal/v4/ {
   return 403 'Forbidden';
 }
 
+location /internal/v5/ {
+  return 403 'Forbidden';
+}
+
 # proxy and log all CC traffic
 location / {
   access_log  /var/vcap/sys/log/cloud_controller_ng/nginx-access.log main;


### PR DESCRIPTION
This change opens a new endpoint in the nginx.conf that was added to the internal syslog_drain_controller lately.
The PR that introduces the new endpoint can be found [here](https://github.com/cloudfoundry/capi-release/commit/b3ae4a6bf12b153ca3e5a4f74fa5860c6eb562d8).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
