### PR TITLE
Pass locket config to cloud_controller_ng and worker

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1225,3 +1225,12 @@ properties:
   cc.kubernetes.kpack.registry_tag_base:
     description: "The first part of the registry tag where built images will be uploaded"
 
+  cc.locket.host:
+    default: "locket.service.cf.internal"
+    description: "Hostname of the Locket server"
+  cc.locket.port:
+    default: 8891
+    description: "Port of the Locket server"
+  cc.locket.diego_client_timeout:
+    default: 5
+    description: "Timeout in seconds for calls by CC's diego client to locket to discover the identity of the active bbs node"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -549,3 +549,11 @@ kubernetes:
 
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: <%= p("cc.custom_metric_tag_prefix_list") %>
+
+locket:
+  host: <%= p("cc.locket.host") %>
+  port: <%= p("cc.locket.port") %>
+  key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls.key
+  cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls.crt
+  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls_ca.crt
+  diego_client_timeout: <%= p("cc.locket.diego_client_timeout") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -572,3 +572,13 @@ properties:
   cc.credential_references.interpolate_service_bindings:
     description: "Controls whether CredHub credentials are automatically interpolated in VCAP_SERVICES"
     default: true
+
+  cc.locket.host:
+    default: "locket.service.cf.internal"
+    description: "Hostname of the Locket server"
+  cc.locket.port:
+    default: 8891
+    description: "Port of the Locket server"
+  cc.locket.diego_client_timeout:
+    default: 5
+    description: "Timeout in seconds for calls by CC's diego client to locket to discover the identity of the active bbs node"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -365,3 +365,11 @@ disable_private_domain_cross_space_context_path_route_sharing: <%= link("cloud_c
 max_labels_per_resource: <%= link("cloud_controller_internal").p("cc.max_labels_per_resource") %>
 max_annotations_per_resource: <%= link("cloud_controller_internal").p("cc.max_annotations_per_resource") %>
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>
+
+locket:
+  host: <%= p("cc.locket.host") %>
+  port: <%= p("cc.locket.port") %>
+  key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls.key
+  cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls.crt
+  ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/mutual_tls_ca.crt
+  diego_client_timeout: <%= p("cc.locket.diego_client_timeout") %>


### PR DESCRIPTION
For full details see the associated PR cloudfoundry/cloud_controller_ng#3002

Note that _this_ PR should be merged first, as the config values it provides are to be mandatory for cloud_controller_ng.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests ~~on bosh lite~~
