### PR TITLE
Add cflinuxfs4 to default configuration to job specs

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -171,6 +171,7 @@ properties:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
@@ -179,6 +180,7 @@ properties:
     description: "List of destination directories for different stacks"
     default:
       "cflinuxfs3": "/home/vcap"
+      "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
       "windows2016": "/Users/vcap"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -517,6 +517,7 @@ properties:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
@@ -525,6 +526,7 @@ properties:
     description: "List of destination directories for different stacks"
     default:
       "cflinuxfs3": "/home/vcap"
+      "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
       "windows2016": "/Users/vcap"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1103,6 +1103,7 @@ properties:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
@@ -1111,6 +1112,7 @@ properties:
     description: "List of destination directories for different stacks"
     default:
       "cflinuxfs3": "/home/vcap"
+      "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
       "windows2016": "/Users/vcap"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -524,6 +524,7 @@ properties:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
       "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+      "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
       "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
@@ -532,6 +533,7 @@ properties:
     description: "List of destination directories for different stacks"
     default:
       "cflinuxfs3": "/home/vcap"
+      "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
       "windows2016": "/Users/vcap"


### PR DESCRIPTION
- Only add cflinuxfs4 to properties that are not overridden in cf-deployment.
- Not sure if we need the stack configuration in all these jobs, but they are there, so I updated them.

[cloudfoundry/cf-deployment#989]
[cloudfoundry/cf-deployment#1008]

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

> Add [cflinuxfs4](https://github.com/cloudfoundry/cflinuxfs4) to some default configuration values. These properties currently use the default value in cf-deployment.

* An explanation of the use cases your change solves

> The Ubuntu version backing cflinuxfs3 will leave support in April 2023. App developers need access to cflinuxfs4, so they can start migrating off of cflinuxfs3.

* Links to any other associated PRs

- cloudfoundry/cf-deployment#989
- cloudfoundry/cf-deployment#1008

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
