### PR TITLE
Make puma max threads configurable

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1210,6 +1210,10 @@ properties:
     description: "Number of workers for Puma webserver."
     default: 3
 
+  cc.puma.max_threads:
+    description: "Maximum number of threads per Puma webserver worker."
+    default: 2
+
   cc.kubernetes.host_url:
     description: "Kubernetes master API URL"
   cc.kubernetes.service_account.name:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -56,6 +56,7 @@ internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 webserver: <%= p("cc.experimental.use_puma_webserver") ? 'puma' : 'thin' %>
 puma:
   workers: <%= p("cc.puma.workers") %>
+  max_threads: <%= p("cc.puma.max_threads") %>
 pid_filename: /var/vcap/data/cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: <%= !!properties.cc.newrelic.license_key || p("cc.development_mode") %>
 development_mode: <%= p("cc.development_mode") %>


### PR DESCRIPTION
Add parameter to configure the max thread number for puma workers

* Links to any other associated PRs
Related to https://github.com/cloudfoundry/cloud_controller_ng/pull/3063


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
