### PR TITLE
Remove `cc_internal_api_user` and `cc_internal_api_password`

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -131,12 +131,6 @@ properties:
     default: "api"
     description: "Host part of the cloud_controller api URI, will be joined with value of 'domain'"
 
-  cc.internal_api_user:
-    default: "internal_user"
-    description: "User name used by Diego to access internal endpoints"
-  cc.internal_api_password:
-    description: "Password used by Diego to access internal endpoints"
-
   cc.logging_level:
     default: "info"
     description: "Log level for cc. Valid levels are listed here: https://github.com/cloudfoundry/steno#log-levels."

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -100,9 +100,6 @@ pending_builds:
 diego_sync:
   frequency_in_seconds: <%= p("cc.diego_sync.frequency_in_seconds") %>
 
-internal_api:
-  auth_user: <%= p("cc.internal_api_user") %>
-  auth_password: <%= yaml_escape(p("cc.internal_api_password")) %>
 
 nginx:
   use_nginx: true

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -386,12 +386,6 @@ properties:
     default: "/var/vcap/data/cloud_controller_ng/diagnostics"
     description: "The directory where operator requested diagnostic files should be placed"
 
-  cc.internal_api_user:
-    default: "internal_user"
-    description: "User name used by Diego to access internal endpoints"
-  cc.internal_api_password:
-    description: "Password used by Diego to access internal endpoints"
-
   cc.min_cli_version:
     description: "Minimum version of the CF CLI to work with the API."
     default: ~

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -101,10 +101,6 @@ instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>
 
-internal_api:
-  auth_user: <%= p("cc.internal_api_user") %>
-  auth_password: <%= yaml_escape(p("cc.internal_api_password")) %>
-
 nginx:
   use_nginx: true
   instance_socket: "/var/vcap/data/cloud_controller_ng/cloud_controller.sock"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -102,12 +102,6 @@ properties:
     default: "api"
     description: "Host part of the cloud_controller api URI, will be joined with value of 'domain'"
 
-  cc.internal_api_user:
-    default: "internal_user"
-    description: "User name used by Diego to access internal endpoints"
-  cc.internal_api_password:
-    description: "Password used by Diego to access internal endpoints"
-
   cc.logging_level:
     default: "info"
     description: "Log level for cc. Valid levels are listed here: https://github.com/cloudfoundry/steno#log-levels."

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -62,10 +62,6 @@ instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 
 default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 
-internal_api:
-  auth_user: <%= p("cc.internal_api_user") %>
-  auth_password: <%= yaml_escape(p("cc.internal_api_password")) %>
-
 nginx:
   use_nginx: true
   instance_socket: "/var/vcap/sys/run/cloud_controller_worker/cloud_controller.sock"

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -61,7 +61,6 @@ module Bosh::Template::Test
                { 'name' => 'python_buildpack', 'package' => 'python-buildpack' },
                { 'name' => 'php_buildpack', 'package' => 'php-buildpack' },
                { 'name' => 'binary_buildpack', 'package' => 'binary-buildpack' }],
-            'internal_api_password' => '((cc_internal_api_password))',
             'mutual_tls' =>
               { 'ca_cert' => '((service_cf_internal_ca.certificate))',
                 'private_key' => '((cc_tls.private_key))',

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -17,7 +17,6 @@ module Bosh::Template::Test
         'system_domain' => 'brook-sentry.capi.land',
 
         'cc' => {
-          'internal_api_password' => '((cc_internal_api_password))',
 
           'db_logging_level' => 100,
           'staging_upload_user' => 'staging_user',


### PR DESCRIPTION
mTLS is required to communicate with the internal api. Thus internal user and password can be removed. 


* Links to any other associated PRs
  Can be merged after CCNG PR [#3134](https://github.com/cloudfoundry/cloud_controller_ng/pull/3134) (should be merged first)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
