### PR TITLE
Remove kubernetes configuration

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -215,13 +215,3 @@ properties:
   cc.locket.port:
     default: 8891
     description: "Port of the Locket server"
-
-  cc.opi.enabled:
-    description: "Set to true to enable running apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.opi_staging:
-    description: "Set to true to enable staging apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.url:
-    description: "URL of the Eirini server"
-    default: ""

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -206,11 +206,6 @@ packages:
   fog_connection: <%= link("cloud_controller_internal").p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.packages.fog_aws_storage_options", {}).to_json %>
 
-opi:
-  url: "<%= p("cc.opi.url") %>"
-  opi_staging: <%= p("cc.opi.opi_staging") %>
-  enabled: <%= p("cc.opi.enabled") %>
-
 droplets:
   blobstore_type: <%= link("cloud_controller_internal").p("cc.droplets.blobstore_type") %>
   webdav_config:

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -26,10 +26,6 @@ templates:
   db_ca.crt.erb: config/certs/db_ca.crt
   credhub_ca.crt.erb: config/certs/credhub_ca.crt
 
-  opi_tls.crt.erb: config/certs/opi_tls.crt
-  opi_tls.key.erb: config/certs/opi_tls.key
-  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
-
 packages:
   - capi_utils
   - cloud_controller_ng

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -327,16 +327,6 @@ diego:
     receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
-opi:
-  url: "<%= link("cloud_controller_internal").p("cc.opi.url") %>"
-  opi_staging: <%= link("cloud_controller_internal").p("cc.opi.opi_staging") %>
-  enabled: <%= link("cloud_controller_internal").p("cc.opi.enabled") %>
-<% link("cloud_controller_internal").if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
-  ca_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls_ca.crt
-  client_cert_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.crt
-  client_key_file: /var/vcap/jobs/cloud_controller_clock/config/certs/opi_tls.key
-<% end %>
-
 <% if p("routing_api.enabled") %>
 routing_api:
   url: <%= "https://api.#{system_domain}/routing" %>

--- a/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.crt.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.client_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls.key.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.client_key") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_clock/templates/opi_tls_ca.crt.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.ca_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -27,7 +27,6 @@ templates:
   logcache_tls.crt.erb: config/certs/logcache_tls.crt
   logcache_tls.key.erb: config/certs/logcache_tls.key
   logcache_tls_ca.crt.erb: config/certs/logcache_tls_ca.crt
-  kubernetes_ca.crt.erb: config/certs/kubernetes_ca.crt
   nginx_external_endpoints.conf.erb: config/nginx_external_endpoints.conf
   migrate_db.sh.erb: bin/migrate_db
   mime.types: config/mime.types
@@ -42,9 +41,6 @@ templates:
   newrelic_plugin.yml.erb: config/newrelic_plugin.yml
   nginx.conf.erb: config/nginx.conf
   nginx_maintenance.conf.erb: config/nginx_maintenance.conf
-  opi_tls.crt.erb: config/certs/opi_tls.crt
-  opi_tls.key.erb: config/certs/opi_tls.key
-  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
   packages_ca_cert.pem.erb: config/certs/packages_ca_cert.pem
   perform_blobstore_benchmarks.erb: bin/perform_blobstore_benchmarks
   post-start.sh.erb: bin/post-start
@@ -164,12 +160,6 @@ provides:
   - cc.max_labels_per_resource
   - cc.max_annotations_per_resource
   - cc.maximum_health_check_timeout
-  - cc.opi.ca_cert
-  - cc.opi.client_cert
-  - cc.opi.client_key
-  - cc.opi.enabled
-  - cc.opi.opi_staging
-  - cc.opi.url
   - cc.packages.app_package_directory_key
   - cc.packages.blobstore_type
   - cc.packages.cdn.key_pair_id
@@ -645,22 +635,6 @@ properties:
   cc.buildpacks.cdn.key_pair_id:
     description: "Key pair name for signed download URIs"
     default: ""
-
-  cc.opi.enabled:
-    description: "Set to true to enable running apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.opi_staging:
-    description: "Set to true to enable staging apps on Kubernetes, using Eirini"
-    default: false
-  cc.opi.url:
-    description: "URL of the Eirini server"
-    default: ""
-  cc.opi.client_cert:
-    description: "Client certificate for connecting to the OPI server"
-  cc.opi.client_key:
-    description: "Client key for connecting to the OPI server"
-  cc.opi.ca_cert:
-    description: "The ca cert of the OPI server"
 
   ccdb.databases:
     description: "Contains the name of the database on the database server"
@@ -1207,21 +1181,6 @@ properties:
   cc.puma.max_threads:
     description: "Maximum number of threads per Puma webserver worker."
     default: 2
-
-  cc.kubernetes.host_url:
-    description: "Kubernetes master API URL"
-  cc.kubernetes.service_account.name:
-    description: "The Kubernetes service account name"
-  cc.kubernetes.service_account.token:
-    description: "The Kubernetes service account token"
-  cc.kubernetes.ca:
-    description: "The CA certificate for connecting to the master"
-  cc.kubernetes.kpack.builder_namespace:
-    description: "The namespace where kpack images and builds will be created"
-  cc.kubernetes.kpack.registry_service_account_name:
-    description: "The name of the kubernetes ServiceAccount that has the credentials to upload to the registry"
-  cc.kubernetes.kpack.registry_tag_base:
-    description: "The first part of the registry tag where built images will be uploaded"
 
   cc.update_metric_tags_on_rename:
     description: "Enable sending a Desired LRP update when an app is renamed"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -487,16 +487,6 @@ diego:
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>
 
-opi:
-  url: "<%= p("cc.opi.url") %>"
-  opi_staging: <%= p("cc.opi.opi_staging") %>
-  enabled: <%= p("cc.opi.enabled") %>
-  cc_uploader_url: "<%= cc_uploader_url %>"
-<% if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
-  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls_ca.crt
-  client_cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls.crt
-  client_key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/opi_tls.key
-<% end %>
 perm:
   enabled: false
 
@@ -525,24 +515,6 @@ max_annotations_per_resource: <%= p("cc.max_annotations_per_resource") %>
 internal_route_vip_range: <%= internal_vip_range %>
 
 threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>
-
-<% if_p("cc.kubernetes.host_url") do %>
-kubernetes:
-  host_url: <%= p("cc.kubernetes.host_url") %>
-
-  service_account:
-    name: <%= p("cc.kubernetes.service_account.name") %>
-    token: <%= p("cc.kubernetes.service_account.token") %>
-
-  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/kubernetes_ca.crt
-
-  <% if_p("cc.kubernetes.kpack.builder_namespace") do %>
-  kpack:
-    builder_namespace: <%= p("cc.kubernetes.kpack.builder_namespace") %>
-    registry_service_account_name: <%= p("cc.kubernetes.kpack.registry_service_account_name") %>
-    registry_tag_base: <%= p("cc.kubernetes.kpack.registry_tag_base") %>
-  <% end %>
-<% end %>
 
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: <%= p("cc.custom_metric_tag_prefix_list") %>

--- a/jobs/cloud_controller_ng/templates/kubernetes_ca.crt.erb
+++ b/jobs/cloud_controller_ng/templates/kubernetes_ca.crt.erb
@@ -1,1 +1,0 @@
-<%= p("cc.kubernetes.ca", '') %>

--- a/jobs/cloud_controller_ng/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls.crt.erb
@@ -1,3 +1,0 @@
-<% if_p("cc.opi.client_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_ng/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls.key.erb
@@ -1,3 +1,0 @@
-<% if_p("cc.opi.client_key") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_ng/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_ng/templates/opi_tls_ca.crt.erb
@@ -1,3 +1,0 @@
-<% if_p("cc.opi.ca_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -34,10 +34,6 @@ templates:
   copilot.crt.erb: config/certs/copilot.crt
   copilot.key.erb: config/certs/copilot.key
 
-  opi_tls.crt.erb: config/certs/opi_tls.crt
-  opi_tls.key.erb: config/certs/opi_tls.key
-  opi_tls_ca.crt.erb: config/certs/opi_tls_ca.crt
-
 packages:
   - capi_utils
   - cloud_controller_ng

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -305,16 +305,6 @@ diego:
     receive_timeout: <%= p("cc.diego.bbs.receive_timeout") %>
   pid_limit: <%= p("cc.diego.pid_limit") %>
 
-opi:
-  url: "<%= link("cloud_controller_internal").p("cc.opi.url") %>"
-  opi_staging: <%= link("cloud_controller_internal").p("cc.opi.opi_staging") %>
-  enabled: <%= link("cloud_controller_internal").p("cc.opi.enabled") %>
-<% link("cloud_controller_internal").if_p("cc.opi.client_cert", "cc.opi.client_key", "cc.opi.ca_cert") do %>
-  ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls_ca.crt
-  client_cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.crt
-  client_key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/opi_tls.key
-<% end %>
-
 <% if p("routing_api.enabled") %>
 routing_api:
   url: <%= "https://api.#{system_domain}/routing" %>

--- a/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.crt.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.client_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls.key.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls.key.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.client_key") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
+++ b/jobs/cloud_controller_worker/templates/opi_tls_ca.crt.erb
@@ -1,3 +1,0 @@
-<% link("cloud_controller_internal").if_p("cc.opi.ca_cert") do |certificate| %>
-<%= certificate %>
-<% end %>

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -65,12 +65,6 @@ module Bosh
               'uaa' => {
                 'client_timeout' => 10
               },
-              'opi' => {
-                'url' => '',
-                'opi_staging' => '',
-                'enabled' => false
-
-              },
               'database_encryption' => {
                 'experimental_pbkdf2_hmac_iterations' => 123,
                 'skip_validation' => false,


### PR DESCRIPTION
- could put back some to help with upgrades since removing a property is usually a breaking change.  But the thought process here is that this wouldn't break bosh based cloud foundries cause the defaults are false.  Needs testing with the correct cloud controller branch still

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Since [capi-k8s-release](https://github.com/cloudfoundry/capi-k8s-release) and [cf-for-k8s](https://github.com/cloudfoundry/cf-for-k8s) are both deprecated and not supported because of [korfi](https://github.com/cloudfoundry/korifi/), it seemed like a reasonable thing to remove kubernetes related code to reduce complexity (maybe)

This was not done with the idea "we should quickly go remove k8s things" but more of a "I wonder if we could"

* An explanation of the use cases your change solves
So I don't have to think about kpack or other things when working cloud controller in a bosh/vms world

* Links to any other associated PRs
[cloud_controller_ng pr](https://github.com/cloudfoundry/cloud_controller_ng/pull/3140)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
passing run of CATS version 12.1.0 on a bosh lite with the following config
```json
{
  "admin_user": "admin",
  "skip_ssl_validation": true,
  "use_http": true,
  "include_apps": true,
  "include_capi_experimental": true,
  "include_detect": true,
  "include_security_groups": true,
  "include_services": true,
  "include_v3": true,
  "include_tasks": true,
  "include_backend_compatibility": false,
  "include_capi_no_bridge": false,
  "include_container_networking": false,
  "include_credhub" : false,
  "include_docker": false,
  "include_internet_dependent": false,
  "include_isolation_segments": false,
  "include_persistent_app": false,
  "include_private_docker_registry": false,
  "include_privileged_container_support": false,
  "include_route_services": false,
  "include_routing": false,
  "include_routing_isolation_segments": false,
  "include_service_discovery": false,
  "include_service_instance_sharing": false,
  "include_ssh": false,
  "include_sso": false,
  "include_zipkin": false
}
```

<details>
<summary>older run of CATS version 9.5.0 with the following config</summary>
```json
{
  "skip_ssl_validation": true,
  "use_http": true,
  "include_apps": true,
  "include_capi_experimental": true,
  "include_detect": true,
  "include_security_groups": true,
  "include_services": true,
  "include_v3": true,
  "include_tasks": true,
  "include_backend_compatibility": false,
  "include_capi_no_bridge": false,
  "include_container_networking": false,
  "include_credhub" : false,
  "include_docker": false,
  "include_internet_dependent": false,
  "include_isolation_segments": false,
  "include_persistent_app": false,
  "include_private_docker_registry": false,
  "include_privileged_container_support": false,
  "include_route_services": false,
  "include_routing": false,
  "include_routing_isolation_segments": false,
  "include_service_discovery": false,
  "include_service_instance_sharing": false,
  "include_ssh": false,
  "include_sso": false,
  "include_zipkin": false
}
```
and had the following failure on a bosh-lite but I didn't retry cause my day ended
```bash
Summarizing 1 Failure:
  [FAIL] [services] Service Instance Lifecycle Synchronous operations when there is an app [BeforeEach] bindings can bind service to app and send arbitrary params
  /home/pivotal/workspace/cf-acceptance-tests/services/service_instance_lifecycle.go:545

Ran 125 of 233 Specs in 3171.070 seconds
FAIL! -- 124 Passed | 1 Failed | 2 Pending | 106 Skipped
```
</details>