### PR TITLE
Update post-backup-unlock.sh.erb

### DIFF
--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -18,4 +18,5 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   monit_start_job cloud_controller_worker_local_<%= index %>
   <% end %>
   wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
+  sleep 30
 <% end %>

--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -14,10 +14,8 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   fi
 
   monit_start_job cloud_controller_ng
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
-  sleep 30
-
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
   monit_start_job cloud_controller_worker_local_<%= index %>
   <% end %>
+  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
 <% end %>


### PR DESCRIPTION
If the timeout fails then the workers never get started, but monit will eventually restart the web process if the CF install eventually recovers, leaving a VM that is half working (with an unhealthy bosh state) after the script runs.

We could also change the exit behavior of the time out with `set +x` (or is it e? I forget), but it would seem that the only point of timing out is to alert the operator to a possible issue since the CC API can still restart.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
