### PR TITLE
Allow dynamic app renaming to be disabled

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1223,3 +1223,6 @@ properties:
   cc.kubernetes.kpack.registry_tag_base:
     description: "The first part of the registry tag where built images will be uploaded"
 
+  cc.update_metric_tags_on_rename:
+    description: "Enable sending a Desired LRP update when an app is renamed"
+    default: true

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -546,3 +546,4 @@ kubernetes:
 
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: <%= p("cc.custom_metric_tag_prefix_list") %>
+update_metric_tags_on_rename: <%= p("cc.update_metric_tags_on_rename") %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Operators may choose to disable support for sending Desired LRP Updates when an application is renamed.

* An explanation of the use cases your change solves
Operators may wish to disable this feature.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/3223: Cloud controller changes required for this PR to work.
https://github.com/cloudfoundry/cloud_controller_ng/pull/3107: Earlier dynamic app renaming PR.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
