### PR TITLE
Use link for cloud_controller_worker stacks.yml to match

### DIFF
--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -133,18 +133,6 @@ properties:
   cc.jobs.priorities:
     description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
 
-  cc.stacks:
-    default:
-      - name: "cflinuxfs3"
-        description: "Cloud Foundry Linux-based filesystem (Ubuntu 18.04)"
-    description: |
-      List of hashes describing stacks intended for developers to choose from when pushing apps.
-      A stack is a prebuilt root file system (rootfs) that supports a specific operating system.
-      Note: removing items in this list will not remove the records in the Cloud Controller's database.
-  cc.default_stack:
-    default: "cflinuxfs3"
-    description: "The default stack name to use if no custom stack is specified by an app."
-
   cc.staging_upload_user:
     description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"
   cc.staging_upload_password:

--- a/jobs/cloud_controller_worker/templates/stacks.yml.erb
+++ b/jobs/cloud_controller_worker/templates/stacks.yml.erb
@@ -1,1 +1,2 @@
-../../../shared_job_templates/stacks.yml.erb
+default: <%= link("cloud_controller_internal").p("cc.default_stack") %>
+stacks: <%= link("cloud_controller_internal").p("cc.stacks", []).to_yaml.gsub("---", "") %>


### PR DESCRIPTION
cloud_controller_ng stacks.yml

- when pushing an app with a buildpack not available for cflinuxfs3 and not specifying the stack, you can get an error like ``` For application 'myapp': Buildpack "somebuildpack" must be an existing admin buildpack or a valid git URI ```
- this happens because the cc.stacks and cc.default_stack was only configured in cloud_controller_ng/spec and not duplicated to cloud_controller_worker/spec
- this commit uses <link> like cc_deployment_updater since there's not much reason we would want this different

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
