### PR TITLE
Use link for cloud_controller_clock stacks.yml to match cloud_control…

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -154,18 +154,6 @@ properties:
     default: 60
     description: "Default health check timeout (in seconds) that can be set for the app"
 
-  cc.stacks:
-    default:
-      - name: "cflinuxfs3"
-        description: "Cloud Foundry Linux-based filesystem (Ubuntu 18.04)"
-    description: |
-      List of hashes describing stacks intended for developers to choose from when pushing apps.
-      A stack is a prebuilt root file system (rootfs) that supports a specific operating system.
-      Note: removing items in this list will not remove the records in the Cloud Controller's database.
-  cc.default_stack:
-    default: "cflinuxfs3"
-    description: "The default stack name to use if no custom stack is specified by an app."
-
   cc.staging_upload_user:
     description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"
   cc.staging_upload_password:

--- a/jobs/cloud_controller_clock/templates/stacks.yml.erb
+++ b/jobs/cloud_controller_clock/templates/stacks.yml.erb
@@ -1,1 +1,2 @@
-../../../shared_job_templates/stacks.yml.erb
+default: <%= link("cloud_controller_internal").p("cc.default_stack") %>
+stacks: <%= link("cloud_controller_internal").p("cc.stacks", []).to_yaml.gsub("---", "") %>


### PR DESCRIPTION
…ler_ng stacks.yml

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

https://github.com/cloudfoundry/capi-release/pull/299 made this change for worker, we should just go ahead and make this change for clock as well

* An explanation of the use cases your change solves

* Links to any other associated PRs

https://github.com/cloudfoundry/capi-release/pull/299

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
