### PR TITLE
Remove cflinuxfs3 and change defaults to cflinuxfs4

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -170,7 +170,6 @@ properties:
   cc.diego.lifecycle_bundles:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
-      "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
@@ -179,7 +178,6 @@ properties:
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
     default:
-      "cflinuxfs3": "/home/vcap"
       "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -498,7 +498,6 @@ properties:
   cc.diego.lifecycle_bundles:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
-      "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
@@ -507,7 +506,6 @@ properties:
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
     default:
-      "cflinuxfs3": "/home/vcap"
       "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -446,14 +446,14 @@ properties:
 
   cc.stacks:
     default:
-      - name: "cflinuxfs3"
-        description: "Cloud Foundry Linux-based filesystem (Ubuntu 18.04)"
+      - name: "cflinuxfs4"
+        description: "Cloud Foundry Linux-based filesystem (Ubuntu 22.04)"
     description: |
       List of hashes describing stacks intended for developers to choose from when pushing apps.
       A stack is a prebuilt root file system (rootfs) that supports a specific operating system.
       Note: removing items in this list will not remove the records in the Cloud Controller's database.
   cc.default_stack:
-    default: "cflinuxfs3"
+    default: "cflinuxfs4"
     description: "The default stack to use if no custom stack is specified for an app."
 
   cc.staging_upload_user:
@@ -1106,7 +1106,6 @@ properties:
   cc.diego.lifecycle_bundles:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
-      "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
@@ -1115,7 +1114,6 @@ properties:
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
     default:
-      "cflinuxfs3": "/home/vcap"
       "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"
@@ -1125,7 +1123,7 @@ properties:
     default: []
   cc.diego.docker_staging_stack:
     description: "stack to use for staging Docker applications"
-    default: "cflinuxfs3"
+    default: "cflinuxfs4"
 
   cc.diego.temporary_oci_buildpack_mode:
     description: "Temporary flag to enable OCI buildpack flow. Valid values: 'oci-phase-1'"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -515,7 +515,6 @@ properties:
   cc.diego.lifecycle_bundles:
     description: "List of lifecycle bundles arguments for different stacks"
     default:
-      "buildpack/cflinuxfs3": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/cflinuxfs4": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
@@ -524,7 +523,6 @@ properties:
   cc.diego.droplet_destinations:
     description: "List of destination directories for different stacks"
     default:
-      "cflinuxfs3": "/home/vcap"
       "cflinuxfs4": "/home/vcap"
       "windows": "/Users/vcap"
       "windows2012R2": "/"

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -102,7 +102,7 @@ module Bosh
                      'rules' => [{ 'destination' => '10.244.0.34', 'protocol' => 'all' }] }],
                 'stacks' =>
                   [{ 'description' => 'Cloud Foundry Linux-based filesystem',
-                     'name' => 'cflinuxfs3' }],
+                     'name' => 'cflinuxfs4' }],
                 'staging_upload_password' => '((cc_staging_upload_password))',
                 'staging_upload_user' => 'staging_user' },
             'ccdb' =>


### PR DESCRIPTION
Now with cf-deployment v28.0.0, the cflinuxfs4 is set as the default stack. This PR aims to removes cflinuxfs3 stack configuration for spec jobs related to cc and changes the defaults. Though, the cflinuxfs3 related configuration entries are still kept in the cf-deployment(overridden).

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
