### PR TITLE
Allow BBR post unlock to proceed if CC api is remotely available

### DIFF
--- a/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
+++ b/jobs/cloud_controller_ng/templates/post-backup-unlock.sh.erb
@@ -17,6 +17,10 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
   <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
   monit_start_job cloud_controller_worker_local_<%= index %>
   <% end %>
-  wait_for_server_to_become_healthy <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
-  sleep 30
+  set +e
+  wait_for_server_to_become_healthy_without_setminuse <%= "localhost:#{p("cc.external_port")}/healthz" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
+  set -e
+  if [ $? -eq 0 ]; then
+    wait_for_server_to_become_healthy <%= "#{p("cc.external_protocol")}://#{p("cc.external_host")}.#{p("system_domain")}/info" %> <%= p("cc.post_bbr_healthcheck_timeout_in_seconds") %>
+  fi
 <% end %>

--- a/src/capi_utils/monit_utils.sh
+++ b/src/capi_utils/monit_utils.sh
@@ -52,6 +52,20 @@ function wait_for_server_to_become_healthy() {
   return 1
 }
 
+function wait_for_server_to_become_healthy_without_setminuse() {
+  local url=$1
+  local timeout=$2
+  for _ in $(seq "${timeout}"); do
+    curl -k -f --connect-timeout 1 "${url}" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Endpoint ${url} failed to become healthy after ${timeout} seconds"
+  return 1
+}
 # monit_monitor_job
 #
 # @param job_name


### PR DESCRIPTION
Previously the unlock health check failed if any single VM was unhealthy because it used the healthz endpoint over a local route

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
