### PR TITLE
Remove deprecated UAA client

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -427,12 +427,6 @@ properties:
     default: "off"
     description: "NewRelic's SQL statement recording mode: [off | obfuscated | raw]"
 
-  uaa.clients.cc_service_broker_client.secret:
-    description: "(DEPRECATED) - Used for generating SSO clients for service brokers."
-  uaa.clients.cc_service_broker_client.scope:
-    description: "(DEPRECATED) - Used to grant scope for SSO clients for service brokers"
-    default: "openid,cloud_controller_service_permissions.read"
-
   uaa.clients.cc-service-dashboards.secret:
     description: "Used for generating SSO clients for service brokers."
   uaa.clients.cc-service-dashboards.scope:

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -284,11 +284,7 @@ database_encryption:
 <% end %>
 
 
-<% if_p("uaa.clients.cc_service_broker_client.secret") do %>
-uaa_client_name: "cc_service_broker_client"
-uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
-uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
-<% end.else_if_p("uaa.clients.cc-service-dashboards.secret") do %>
+<% if_p("uaa.clients.cc-service-dashboards.secret") do %>
 uaa_client_name: "cc-service-dashboards"
 uaa_client_secret: <%= p("uaa.clients.cc-service-dashboards.secret") %>
 uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -943,12 +943,6 @@ properties:
     description: "Maximum depth of inlined relationships in the result"
     default: 2
 
-  uaa.clients.cc_service_broker_client.secret:
-    description: "(DEPRECATED) - Used for generating SSO clients for service brokers"
-  uaa.clients.cc_service_broker_client.scope:
-    description: "(DEPRECATED) - Used to grant scope for SSO clients for service brokers"
-    default: "openid,cloud_controller_service_permissions.read"
-
   uaa.clients.cc-service-dashboards.secret:
     description: "Used for generating SSO clients for service brokers."
   uaa.clients.cc-service-dashboards.scope:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -394,11 +394,7 @@ renderer:
   default_results_per_page: <%= p("cc.renderer.default_results_per_page") %>
   max_inline_relations_depth: <%= p("cc.renderer.max_inline_relations_depth") %>
 
-<% if_p("uaa.clients.cc_service_broker_client.secret") do %>
-uaa_client_name: "cc_service_broker_client"
-uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
-uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
-<% end.else_if_p("uaa.clients.cc-service-dashboards.secret") do %>
+<% if_p("uaa.clients.cc-service-dashboards.secret") do %>
 uaa_client_name: "cc-service-dashboards"
 uaa_client_secret: <%= p("uaa.clients.cc-service-dashboards.secret") %>
 uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -418,12 +418,6 @@ properties:
     default: 1
     description: "Number of generic cloud_controller_worker workers"
 
-  uaa.clients.cc_service_broker_client.secret:
-    description: "(DEPRECATED) - Used for generating SSO clients for service brokers."
-  uaa.clients.cc_service_broker_client.scope:
-    description: "(DEPRECATED) - Used to grant scope for SSO clients for service brokers"
-    default: "openid,cloud_controller_service_permissions.read"
-
   uaa.clients.cc-service-dashboards.secret:
     description: "Used for generating SSO clients for service brokers."
   uaa.clients.cc-service-dashboards.scope:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -265,11 +265,7 @@ broker_client_response_parser:
   log_validators: <%= p("cc.broker_client_response_parser.log_validators") %>
   log_response_fields: <%= p("cc.broker_client_response_parser.log_response_fields").to_json %>
 
-<% if_p("uaa.clients.cc_service_broker_client.secret") do %>
-uaa_client_name: "cc_service_broker_client"
-uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
-uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
-<% end.else_if_p("uaa.clients.cc-service-dashboards.secret") do %>
+<% if_p("uaa.clients.cc-service-dashboards.secret") do %>
 uaa_client_name: "cc-service-dashboards"
 uaa_client_secret: <%= p("uaa.clients.cc-service-dashboards.secret") %>
 uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>


### PR DESCRIPTION
The `uaa.clients.cc_service_broker_client` property is deprecated for years, so it's time to get rid of it.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
