### PR TITLE
Add optional cc `max_total_results` parameter

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -916,6 +916,8 @@ properties:
   cc.renderer.max_inline_relations_depth:
     description: "Maximum depth of inlined relationships in the result"
     default: 2
+  cc.renderer.max_total_results:
+    description: "Maximum number of total results (page * per_page)"
 
   uaa.clients.cc_service_broker_client.secret:
     description: "(DEPRECATED) - Used for generating SSO clients for service brokers"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -393,6 +393,9 @@ renderer:
   max_results_per_page: <%= p("cc.renderer.max_results_per_page") %>
   default_results_per_page: <%= p("cc.renderer.default_results_per_page") %>
   max_inline_relations_depth: <%= p("cc.renderer.max_inline_relations_depth") %>
+  <% if_p("cc.renderer.max_total_results") do |max_total_results| %>
+  max_total_results: <%= max_total_results %>
+  <% end %>
 
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -624,6 +624,23 @@ module Bosh
               end
             end
           end
+
+          describe  'max_total_results' do
+            context "when 'cc.renderer.max_total_results' is set" do
+              it 'renders max_total_results into the ccng config' do
+                merged_manifest_properties['cc'].store('renderer', { 'max_total_results' => 1000 })
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['renderer']['max_total_results']).to eq(1000)
+              end
+            end
+
+            context "when 'cc.renderer.max_total_results' is not set (default)" do
+              it 'does not render max_total_results into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['renderer']).not_to have_key(:max_total_results)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/pull/3353 introduced a new optional parameter `max_total_results` to prevent requests with a large number of total results (`per_page * page`) as those requests can cause expensive db queries.
This PR allows operators to configure the maximum number of total results via the parameter `cc.renderer.max_total_results`.


* Links to any other associated PRs
Related to https://github.com/cloudfoundry/cloud_controller_ng/pull/3353

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
