### PR TITLE
The failed_jobs cleanup job should run more often than once per day

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -110,6 +110,9 @@ properties:
     description: "The age at which completed tasks are pruned from the Cloud Controller database"
     default: 31
 
+  cc.failed_jobs.max_number_of_failed_delayed_jobs:
+    description: "Maximum number of failed jobs that should stay in cloud controller database before being cleaned up"
+
   cc.pending_droplets.frequency_in_seconds:
     description: "How often the pending droplets cleanup job runs"
     default: 300
@@ -119,6 +122,9 @@ properties:
   cc.diego_sync.frequency_in_seconds:
     description: "How often to synchronize CC's database with Diego's"
     default: 30
+  cc.failed_jobs.frequency_in_seconds:
+    description: "How often the failed_jobs cleanup job runs"
+    default: 144000 # 4 hours
 
   cc.external_protocol:
     default: "https"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -85,6 +85,10 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: <%= p("cc.failed_jobs.cutoff_age_in_days") %>
+  <% if_p("cc.failed_jobs.max_number_of_failed_delayed_jobs") do |max_number_of_failed_delayed_jobs| %>
+  max_number_of_failed_delayed_jobs: <%= max_number_of_failed_delayed_jobs %>
+  <% end %>
+  frequency_in_seconds: <%= p("cc.failed_jobs.frequency_in_seconds") %>
 
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>

--- a/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
+++ b/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+module Bosh
+  module Template
+    module Test
+      describe 'cloud_controller_ng job template rendering' do
+        let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+        let(:release) { ReleaseDir.new(release_path) }
+        let(:job) { release.job('cloud_controller_clock') }
+
+        let(:manifest_properties) do
+          {
+            'system_domain' => 'brook-sentry.capi.land',
+
+            'cc' => {
+
+              'db_logging_level' => 100,
+              'staging_upload_user' => 'staging_user',
+              'staging_upload_password' => 'hunter2',
+              'database_encryption' => {
+                'experimental_pbkdf2_hmac_iterations' => 123,
+                'skip_validation' => false,
+                'current_key_label' => 'encryption_key_0',
+                :keys => { 'encryption_key_0' => '((cc_db_encryption_key))' }
+              }
+            },
+            'ccdb' => {
+              'db_scheme' => 'mysql',
+              'max_connections' => 'foo2',
+              'databases' => [{ 'tag' => 'cc' }],
+              'roles' => [{
+                'tag' => 'admin',
+                'name' => 'alex',
+                'password' => 'pass'
+              }],
+              'address' => 'foo5',
+              'port' => 'foo7',
+              'pool_timeout' => 'foo11',
+              'ssl_verify_hostname' => 'foo12',
+              'read_timeout' => 'foo13',
+              'connection_validation_timeout' => 'foo14',
+              'ca_cert' => 'foo15'
+            }
+          }
+        end
+
+        let(:properties) do
+          {
+            'router' => { 'route_services_secret' => '((router_route_services_secret))' },
+            'cc' => {
+              'system_hostnames' => '',
+              'logging_max_retries' => 'bar1',
+              'default_app_ssh_access' => 'something',
+              'logging_level' => 'other thing',
+              'log_db_queries' => 'balsdkj',
+              'logging' => { 'format' => { 'timestamp' => 'rfc3339' } },
+              'db_logging_level' => 'bar2',
+              'db_encryption_key' => 'bar3',
+              'volume_services_enabled' => true,
+              'uaa' => {
+                'client_timeout' => 10
+              },
+              'database_encryption' => {
+                'experimental_pbkdf2_hmac_iterations' => 123,
+                'skip_validation' => false,
+                'current_key_label' => 'encryption_key_0',
+                :keys => { 'encryption_key_0' => '((cc_db_encryption_key))' }
+              },
+              'max_labels_per_resource' => true,
+              'max_annotations_per_resource' => 'yus',
+              'disable_private_domain_cross_space_context_path_route_sharing' => false,
+              'custom_metric_tag_prefix_list' => ['heck.yes.example.com']
+            }
+          }
+        end
+        let(:cloud_controller_internal_link) do
+          Link.new(name: 'cloud_controller_internal', properties:, instances: [LinkInstance.new(address: 'default_app_ssh_access')])
+        end
+
+        let(:cloud_controller_db_link) do
+          properties = {
+            'ccdb' => {
+              'db_scheme' => 'mysql',
+              'max_connections' => 'foo2',
+              'databases' => [{ 'tag' => 'cc' }],
+              'roles' => [{
+                'tag' => 'admin',
+                'name' => 'alex',
+                'password' => 'pass'
+              }],
+              'address' => 'foo5',
+              'port' => 'foo7',
+              'pool_timeout' => 'foo11',
+              'ssl_verify_hostname' => 'foo12',
+              'read_timeout' => 'foo13',
+              'connection_validation_timeout' => 'foo14',
+              'ca_cert' => 'foo15'
+            }
+          }
+          Link.new(name: 'database', properties:, instances: [LinkInstance.new(address: 'cloud_controller_db')])
+        end
+
+        let(:links) { [cloud_controller_internal_link, cloud_controller_db_link] }
+
+        let(:template) { job.template('config/cloud_controller_ng.yml') }
+
+        it 'creates the cloud_controller_ng.yml config file' do
+          expect do
+            YAML.safe_load(template.render(manifest_properties, consumes: links))
+          end.not_to raise_error
+        end
+
+        describe 'max_number_of_failed_delayed_jobs' do
+          context "when 'cc.failed_jobs.max_number_of_failed_delayed_jobs' is set" do
+            it 'renders max_number_of_failed_delayed_jobs into the ccng config' do
+              manifest_properties['cc'].store('failed_jobs', { 'max_number_of_failed_delayed_jobs' => 1000 })
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['failed_jobs']['max_number_of_failed_delayed_jobs']).to eq(1000)
+            end
+          end
+
+          context "when 'cc.failed_jobs.max_number_of_failed_delayed_jobs' is not set (default)" do
+            it 'does not render max_number_of_failed_delayed_jobs into the ccng config' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['failed_jobs']).not_to have_key(:max_number_of_failed_delayed_jobs)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
So far failed_jobs was running once per day. We want to let it run more often, therefore we need to add the necessary params.
Failed_jobs is changed to also cleanup failed entries from the delayed_jobs table that exceeds a defined maximum number of entries in order to prevent overload of the db. The new parameter max_number_of_failed_delayed_jobs is optional. 
With this change the job should runs more often than once per day (default is every 4h) to ensure db is not overloaded.


* Links to any other associated PRs
Related to https://github.com/cloudfoundry/cloud_controller_ng/pull/3346

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
