### PR TITLE
Extract Redis tar more resilient

### DIFF
--- a/packages/redis/packaging
+++ b/packages/redis/packaging
@@ -4,7 +4,7 @@ function main() {
   local redis_version
   redis_version="7.0.11"
 
-  tar xzf "redis/${redis_version}.tar.gz"
+  mkdir -p "redis-${redis_version}" && tar xzf "redis/${redis_version}.tar.gz" -C "redis-${redis_version}" --strip-components=1
 
   pushd "redis-${redis_version}" > /dev/null
     make


### PR DESCRIPTION
The root dir of the Redis tar file can have various names depending on where/ how it is downloaded:
- When the tar is downloaded via the Concourse 'github-release-resource' the dir will be named 'redis-redis-<commit-hash>'.
- However when the tar is manually downloaded from the redis github release (e.g. https://github.com/redis/redis/archive/refs/tags/7.0.12.tar.gz) the dir will be named 'redis-<version-number>'

-> All other files of the tar are identical as they are based on the same github release.

To avoid packaging errors during deploy time this change ensures that the extracted root dir of the tar file will be named 'redis-<version-number>'. This will also prevent version conflicts.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
