### PR TITLE
Revert "Bump all nginx related packages"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-expat/expat-2.5.0.tar.bz2:
-  size: 569205
-  object_id: 970ccd16-75ac-4c55-5280-c00c4aa8f6cc
-  sha: sha256:6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67
+expat/expat-2.3.0.tar.bz2:
+  size: 533513
+  object_id: 20689f9c-8d1a-464f-54eb-5386806cfd47
+  sha: sha256:f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586
 mariadb_connector_c/mariadb-connector-c-3.3.5-src.tar.gz:
   size: 1392609
   object_id: ca059f02-93a8-491b-74cb-44dcc0a59bbc
@@ -70,10 +70,10 @@ nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   size: 5222
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d
   sha: sha256:a5a7f9b3a7e20302943b1dd448d9b725cf3cb28d774d79f618aab7c4ddeea52b
-nginx/nginx-1.24.0.tar.gz:
-  size: 1112471
-  object_id: 9f4b0776-b3cc-4f0b-4fbc-e92e9123ab90
-  sha: sha256:77a2541637b92a621e3ee76776c8b7b40cf6d707e69ba53a940283e30ff2f55d
+nginx/nginx-1.21.6.tar.gz:
+  size: 1073364
+  object_id: 70f0dcea-e96a-4522-4a6c-588d551b7397
+  sha: sha256:66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae
 nginx/nginx-dav-ext-module-3.0.0.tar.gz:
   size: 14558
   object_id: 44648d53-c24b-45e4-4434-007713aa5fe7
@@ -82,10 +82,10 @@ nginx/nginx-upload-module-2.3.0.tar.gz:
   size: 40139
   object_id: 2f8f59a7-8e90-4bf5-67d8-1637924ab331
   sha: sha256:c86e318addb9c88d70fdbd58ff1f6ef6f404a93070f6db8017a1f880c97946c4
-nginx/pcre2-10.42.tar.gz:
-  size: 2397194
-  object_id: 674bb628-9cde-4f9f-5584-d6bffba72844
-  sha: sha256:c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f
+nginx/pcre-8.45.tar.gz:
+  size: 2096552
+  object_id: a90f9f20-e23b-4755-59c7-101197325dab
+  sha: sha256:4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09
 postgres/postgresql-11.21.tar.gz:
   size: 26792160
   object_id: f09b27ec-4351-499d-6414-8d5656e7f45c

--- a/packages/nginx/README.md
+++ b/packages/nginx/README.md
@@ -4,8 +4,8 @@ This repo is used for nginx and nginx-webdav packaging in BOSH deployments.
 
 The files can be downloaded from the following locations:
 
-| Filename                         | Download URL                                                                                                     |
-|----------------------------------|------------------------------------------------------------------------------------------------------------------|
-| nginx-1.24.0.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.24.0.tar.gz)                                                       |
-| nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz) 
-| pcre2-10.42.tar.gz | [https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz]                         |
+| Filename | Download URL |
+| -------- | ------------ |
+| nginx-1.21.6.tar.gz | [nginx.org](http://nginx.org/download/nginx-1.21.6.tar.gz) |
+| nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz)
+| pcre-8.45.tar.gz | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz) |

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -1,7 +1,7 @@
 set -e -x
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre2-10.42.tar.gz
+tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx_upload module..."
 tar xzvf nginx/nginx-upload-module-2.3.0.tar.gz
@@ -13,13 +13,13 @@ pushd nginx-upload-module-2.3.0
 popd
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.24.0.tar.gz
+tar xzvf nginx/nginx-1.21.6.tar.gz
 
 echo "Building nginx..."
-pushd nginx-1.24.0
+pushd nginx-1.21.6
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
-    --with-pcre=../pcre2-10.42 \
+    --with-pcre=../pcre-8.45 \
     --add-module=../nginx-upload-module-2.3.0 \
     --with-http_stub_status_module \
     --with-http_ssl_module

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -1,8 +1,8 @@
 ---
 name: nginx
 files:
-- nginx/nginx-1.24.0.tar.gz
-- nginx/pcre2-10.42.tar.gz
+- nginx/nginx-1.21.6.tar.gz
+- nginx/pcre-8.45.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch
 - nginx/upload_module_new_nginx_support.patch

--- a/packages/nginx_webdav/README.md
+++ b/packages/nginx_webdav/README.md
@@ -4,7 +4,7 @@ This is the nginx we use to front our blobstore.
 
 This file can be downloaded from the following locations:
 
-| Filename                                | Homepage | Download URL |
-|-----------------------------------------| -------- | ------------ |
-| expat/expat-2.5.0.tar.bz2               | https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.gz |
+| Filename | Homepage | Download URL |
+| -------- | -------- | ------------ |
+| expat/expat-2.3.0.tar.bz2 | https://github.com/libexpat/libexpat| https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-2.3.0.tar.bz2 |
 | nginx/nginx-dav-ext-module-3.0.0.tar.gz | https://github.com/arut/nginx-dav-ext-module | https://github.com/arut/nginx-dav-ext-module/archive/v3.0.0.tar.gz |

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -1,9 +1,9 @@
 set -e -x
 
 echo "Extracting expat..."
-tar xvf expat/expat-2.5.0.tar.bz2
+tar xvf expat/expat-2.3.0.tar.bz2
 
-pushd expat-2.5.0
+pushd expat-2.3.0
     ./configure
 
     make
@@ -12,21 +12,21 @@ pushd expat-2.5.0
 popd
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre2-10.42.tar.gz
+tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.24.0.tar.gz
+tar xzvf nginx/nginx-1.21.6.tar.gz
 
 echo "Extracting webdav extensions"
 tar xzvf nginx/nginx-dav-ext-module-3.0.0.tar.gz
 
 echo "Building nginx..."
-pushd nginx-1.24.0
+pushd nginx-1.21.6
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \
     --with-cc-opt="-I /usr/local/include" \
-    --with-pcre=../pcre2-10.42 \
+    --with-pcre=../pcre-8.45 \
     --with-http_dav_module \
     --with-http_secure_link_module \
     --with-http_ssl_module \

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -1,7 +1,7 @@
 ---
 name: nginx_webdav
 files:
-  - expat/expat-2.5.0.tar.bz2
-  - nginx/nginx-1.24.0.tar.gz
-  - nginx/pcre2-10.42.tar.gz
+  - expat/expat-2.3.0.tar.bz2
+  - nginx/nginx-1.21.6.tar.gz
+  - nginx/pcre-8.45.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz


### PR DESCRIPTION
Reverts cloudfoundry/capi-release#346

Causes test failures. Needs further investigation.