### PR TITLE
Add 'fog_gcp_storage_options' parameter

### DIFF
--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -183,6 +183,7 @@ resource_pool:
   <% end %>
   fog_connection: <%= link("cloud_controller_internal").p("cc.resource_pool.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.resource_pool.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= link("cloud_controller_internal").p("cc.resource_pool.fog_gcp_storage_options", {}).to_json %>
 
 packages:
   blobstore_type: <%= link("cloud_controller_internal").p("cc.packages.blobstore_type") %>
@@ -205,6 +206,8 @@ packages:
   <% end %>
   fog_connection: <%= link("cloud_controller_internal").p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.packages.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= link("cloud_controller_internal").p("cc.packages.fog_gcp_storage_options", {}).to_json %>
+
 
 droplets:
   blobstore_type: <%= link("cloud_controller_internal").p("cc.droplets.blobstore_type") %>
@@ -226,6 +229,7 @@ droplets:
   <% end %>
   fog_connection: <%= link("cloud_controller_internal").p("cc.droplets.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.droplets.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= link("cloud_controller_internal").p("cc.droplets.fog_gcp_storage_options", {}).to_json %>
 
 buildpacks:
   blobstore_type: <%= link("cloud_controller_internal").p("cc.buildpacks.blobstore_type") %>
@@ -247,6 +251,7 @@ buildpacks:
   <% end %>
   fog_connection: <%= link("cloud_controller_internal").p("cc.buildpacks.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= link("cloud_controller_internal").p("cc.buildpacks.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= link("cloud_controller_internal").p("cc.buildpacks.fog_gcp_storage_options", {}).to_json %>
 
 skip_cert_verify: <%= link("cloud_controller_internal").p("ssl.skip_cert_verify") %>
 

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -166,6 +166,8 @@ properties:
     default: "fog"
   cc.resource_pool.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.resource_pool.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.resource_pool.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -210,6 +212,8 @@ properties:
     default: "fog"
   cc.packages.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.packages.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.packages.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -251,6 +255,8 @@ properties:
     default: "fog"
   cc.droplets.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.droplets.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.droplets.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -289,6 +295,8 @@ properties:
     default: "fog"
   cc.buildpacks.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.buildpacks.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.buildpacks.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -201,6 +201,7 @@ resource_pool:
   <% end %>
   fog_connection: <%= p("cc.resource_pool.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.resource_pool.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.resource_pool.fog_gcp_storage_options", {}).to_json %>
 
 packages:
   blobstore_type: <%= p("cc.packages.blobstore_type") %>
@@ -223,6 +224,7 @@ packages:
   <% end %>
   fog_connection: <%= p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.packages.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.packages.fog_gcp_storage_options", {}).to_json %>
 
 droplets:
   blobstore_type: <%= p("cc.droplets.blobstore_type") %>
@@ -244,6 +246,7 @@ droplets:
   <% end %>
   fog_connection: <%= p("cc.droplets.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.droplets.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.droplets.fog_gcp_storage_options", {}).to_json %>
 
 buildpacks:
   blobstore_type: <%= p("cc.buildpacks.blobstore_type") %>
@@ -265,6 +268,7 @@ buildpacks:
   <% end %>
   fog_connection: <%= p("cc.buildpacks.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.buildpacks.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.buildpacks.fog_gcp_storage_options", {}).to_json %>
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -124,6 +124,7 @@ provides:
   - cc.buildpacks.cdn.private_key
   - cc.buildpacks.cdn.uri
   - cc.buildpacks.fog_aws_storage_options
+  - cc.buildpacks.fog_gcp_storage_options
   - cc.buildpacks.fog_connection
   - cc.buildpacks.webdav_config.blobstore_timeout
   - cc.buildpacks.webdav_config.ca_cert
@@ -148,6 +149,7 @@ provides:
   - cc.droplets.cdn.uri
   - cc.droplets.droplet_directory_key
   - cc.droplets.fog_aws_storage_options
+  - cc.droplets.fog_gcp_storage_options
   - cc.droplets.fog_connection
   - cc.droplets.webdav_config.blobstore_timeout
   - cc.droplets.webdav_config.ca_cert
@@ -173,6 +175,7 @@ provides:
   - cc.packages.cdn.private_key
   - cc.packages.cdn.uri
   - cc.packages.fog_aws_storage_options
+  - cc.packages.fog_gcp_storage_options
   - cc.packages.fog_connection
   - cc.packages.max_package_size
   - cc.packages.webdav_config.blobstore_timeout
@@ -186,6 +189,7 @@ provides:
   - cc.resource_pool.cdn.private_key
   - cc.resource_pool.cdn.uri
   - cc.resource_pool.fog_aws_storage_options
+  - cc.resource_pool.fog_gcp_storage_options
   - cc.resource_pool.fog_connection
   - cc.resource_pool.maximum_size
   - cc.resource_pool.minimum_size
@@ -483,6 +487,9 @@ properties:
   cc.resource_pool.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. See http://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-aws-sse for example configuration."
     default: {}
+  cc.resource_pool.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
+    default: {}
   cc.resource_pool.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -527,6 +534,9 @@ properties:
     default: "fog"
   cc.packages.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. See http://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-aws-sse for example configuration."
+    default: {}
+  cc.packages.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
     default: {}
   cc.packages.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
@@ -573,6 +583,9 @@ properties:
   cc.droplets.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. See http://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-aws-sse for example configuration."
     default: {}
+  cc.droplets.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
+    default: {}
   cc.droplets.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -614,6 +627,9 @@ properties:
     default: "fog"
   cc.buildpacks.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. See http://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-aws-sse for example configuration."
+    default: {}
+  cc.buildpacks.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
     default: {}
   cc.buildpacks.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -287,6 +287,7 @@ resource_pool:
   <% end %>
   fog_connection: <%= p("cc.resource_pool.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.resource_pool.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.resource_pool.fog_gcp_storage_options", {}).to_json %>
 
 packages:
   blobstore_type: <%= p("cc.packages.blobstore_type") %>
@@ -310,6 +311,7 @@ packages:
   <% end %>
   fog_connection: <%= p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.packages.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.packages.fog_gcp_storage_options", {}).to_json %>
 
 droplets:
   blobstore_type: <%= p("cc.droplets.blobstore_type") %>
@@ -331,6 +333,7 @@ droplets:
   <% end %>
   fog_connection: <%= p("cc.droplets.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.droplets.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.droplets.fog_gcp_storage_options", {}).to_json %>
   max_staged_droplets_stored: <%= p("cc.droplets.max_staged_droplets_stored") %>
 
 buildpacks:
@@ -353,6 +356,7 @@ buildpacks:
   <% end %>
   fog_connection: <%= p("cc.buildpacks.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.buildpacks.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.buildpacks.fog_gcp_storage_options", {}).to_json %>
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -139,6 +139,8 @@ properties:
     default: "fog"
   cc.resource_pool.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.resource_pool.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.resource_pool.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -183,6 +185,8 @@ properties:
     default: "fog"
   cc.packages.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.packages.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.packages.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -224,6 +228,8 @@ properties:
     default: "fog"
   cc.droplets.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.droplets.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.droplets.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5
@@ -262,6 +268,8 @@ properties:
     default: "fog"
   cc.buildpacks.fog_aws_storage_options:
     description: "Storage options passed to fog for aws blobstores. Valid keys: ['encryption']."
+  cc.buildpacks.fog_gcp_storage_options:
+    description: "Storage options passed to fog for gcp blobstores"
   cc.buildpacks.webdav_config.blobstore_timeout:
     description: "The timeout in seconds for requests to the blobstore"
     default: 5

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -167,6 +167,7 @@ resource_pool:
   <% end %>
   fog_connection: <%= p("cc.resource_pool.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.resource_pool.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.resource_pool.fog_gcp_storage_options", {}).to_json %>
 
 packages:
   blobstore_type: <%= p("cc.packages.blobstore_type") %>
@@ -189,6 +190,7 @@ packages:
   <% end %>
   fog_connection: <%= p("cc.packages.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.packages.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.packages.fog_gcp_storage_options", {}).to_json %>
 
 droplets:
   blobstore_type: <%= p("cc.droplets.blobstore_type") %>
@@ -210,6 +212,7 @@ droplets:
   <% end %>
   fog_connection: <%= p("cc.droplets.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.droplets.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.droplets.fog_gcp_storage_options", {}).to_json %>
 
 buildpacks:
   blobstore_type: <%= p("cc.buildpacks.blobstore_type") %>
@@ -231,6 +234,7 @@ buildpacks:
   <% end %>
   fog_connection: <%= p("cc.buildpacks.fog_connection", {}).to_json %>
   fog_aws_storage_options: <%= p("cc.buildpacks.fog_aws_storage_options", {}).to_json %>
+  fog_gcp_storage_options: <%= p("cc.buildpacks.fog_gcp_storage_options", {}).to_json %>
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 


### PR DESCRIPTION
ccng allows to configure storage options for the gcp fog library. This can be done via the 'fog_gcp_storage_options' parameter. Related ccng PR: [#3463](https://github.com/cloudfoundry/cloud_controller_ng/pull/3463) Commit: 6a747fe3110cd27a0383b83355f65e65a4564f1a

This change introduces 'fog_gcp_storage_options' parameter in capi-release.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
