### PR TITLE
Add config flag to disable prom_scraper

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1073,6 +1073,10 @@ properties:
   cc.public_tls.private_key:
     description: "PEM-encoded key for secure TLS communication over external endpoints"
 
+  cc.prom_scraper.disabled:
+    description: "When set to true, the prom_scraper job won't scrape the Cloud Controller's metrics. 
+                  Use this if you have another scraper in place and to prevent scraping metrics twice."
+    default: false
   cc.prom_scraper_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication with prom_scraper"
   cc.prom_scraper_tls.public_cert:

--- a/jobs/cloud_controller_ng/templates/prom_scraper_config.yml.erb
+++ b/jobs/cloud_controller_ng/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% if p("cc.prom_scraper.disabled") != true -%>
 port: <%= p("cc.prom_metrics_server_tls_port") %>
 source_id: "cloud_controller_ng"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p("cc.internal_service_hostname") %>
 path: /internal/v4/metrics
+<% end -%>

--- a/spec/cloud_controller_ng/prom_scraper_spec.rb
+++ b/spec/cloud_controller_ng/prom_scraper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh
+  module Template
+    module Test
+      describe 'prom_scraper config template rendering' do
+        let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+        let(:release) { ReleaseDir.new(release_path) }
+        let(:job) { release.job('cloud_controller_ng') }
+
+        describe 'prom_scraper_config.yml' do
+          let(:template) { job.template('config/prom_scraper_config.yml') }
+          let(:manifest_properties) { {} }
+
+          before do
+            @rendered_file = template.render(manifest_properties, consumes: {})
+          end
+
+          it 'renders default values' do
+            expect(@rendered_file).to include('port: 9025')
+          end
+
+          context 'when prom_scraper is disabled' do
+            let(:manifest_properties) { { 'cc' => { 'prom_scraper' => { 'disabled' => true } } } }
+
+            it 'renders an empty file' do
+              expect(@rendered_file).not_to include('port: 9025')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* A short explanation of the proposed change:
Introducing a flag which, when set to true, will render the prom_scraper_config.yml empty and therefore it will be ignored by the prom_scraper. This is useful if you want to use another scraper.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
