### PR TITLE
Increase default max nginx upload size to 2GB

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -768,7 +768,7 @@ properties:
     default: "15M"
     description: "Maximum body size for nginx"
   cc.app_bits_max_body_size:
-    default: "1536M"
+    default: "2048M"
     description: "Maximum body size for nginx bits uploads"
 
   cc.default_app_log_rate_limit_in_bytes_per_second:


### PR DESCRIPTION
## What
In order to support new versions of the Java buildpack, and CNBs in the future, we should increase the default max upload-able file size to 2GB. See this issue: 
- https://github.com/cloudfoundry/java-buildpack/issues/1035

[#186470719](https://www.pivotaltracker.com/story/show/186470719)

## Checklist
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
