### PR TITLE
Add statsd_host + statsd_port to cloud_controller_clock job

### DIFF
--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -347,6 +347,9 @@ credhub_api:
 credential_references:
   interpolate_service_bindings: <%= p("cc.credential_references.interpolate_service_bindings") %>
 
+statsd_host: <%= link("cloud_controller_internal").p("cc.statsd_host") %>
+statsd_port: <%= link("cloud_controller_internal").p("cc.statsd_port") %>
+
 max_labels_per_resource: <%= link("cloud_controller_internal").p("cc.max_labels_per_resource") %>
 max_annotations_per_resource: <%= link("cloud_controller_internal").p("cc.max_annotations_per_resource") %>
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
+++ b/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
@@ -71,6 +71,8 @@ module Bosh
                 'current_key_label' => 'encryption_key_0',
                 :keys => { 'encryption_key_0' => '((cc_db_encryption_key))' }
               },
+              'statsd_host' => '127.0.0.1',
+              'statsd_port' => 8125,
               'max_labels_per_resource' => true,
               'max_annotations_per_resource' => 'yus',
               'disable_private_domain_cross_space_context_path_route_sharing' => false,
@@ -129,6 +131,14 @@ module Bosh
               template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
               expect(template_hash['failed_jobs']).not_to have_key(:max_number_of_failed_delayed_jobs)
             end
+          end
+        end
+
+        describe 'statsd' do
+          it 'renders statsd_host and statsd_port from cloud_controller_internal link' do
+            template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+            expect(template_hash['statsd_host']).to eq(properties['cc']['statsd_host'])
+            expect(template_hash['statsd_port']).to eq(properties['cc']['statsd_port'])
           end
         end
       end


### PR DESCRIPTION
Don't rely on default values, but use the configured statsd host + port as done by the `cc_deployment_updater` job.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
