### PR TITLE
Make Nginx healthcheck script to tolerate unavailability

### DIFF
--- a/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
+++ b/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
@@ -51,8 +51,10 @@ while true; do
   status=$?
   set -e
   if [[ $status > 0 ]] ; then
-    echo $(date --rfc-3339=ns) "ccng_monit_http_healthcheck failed to curl <${URL}>: exit code $status"
-    exit $status
+    echo "$(date --rfc-3339=ns) ccng_monit_http_healthcheck failed to curl <${URL}>: exit code $status"
+    if [[ $status != 7 ]] ; then
+      exit $status
+    fi
   fi
   sleep 10
 done


### PR DESCRIPTION
* A short explanation of the proposed change:
Addresses https://github.com/cloudfoundry/capi-release/issues/364 health check will wait and retry if Nginx is not available.

* An explanation of the use cases your change solves
This change allows Nginx and webserver to start without monit interruption.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
