### PR TITLE
Add legacy_md5_buildpack_paths_enabled param

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1212,3 +1212,7 @@ properties:
   cc.update_metric_tags_on_rename:
     description: "Enable sending a Desired LRP update when an app is renamed"
     default: true
+
+  cc.legacy_md5_buildpack_paths_enabled:
+    description: "Enable legacy MD5 buildpack paths. If disabled, xxhash64 is used for calculating paths in buildpack image layers."
+    default: true

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -522,3 +522,5 @@ threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: <%= p("cc.custom_metric_tag_prefix_list") %>
 update_metric_tags_on_rename: <%= p("cc.update_metric_tags_on_rename") %>
+
+legacy_md5_buildpack_paths_enabled: <%= p("cc.legacy_md5_buildpack_paths_enabled") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -592,7 +592,7 @@ module Bosh
             end
           end
 
-          describe  'max_total_results' do
+          describe 'max_total_results' do
             context "when 'cc.renderer.max_total_results' is set" do
               it 'renders max_total_results into the ccng config' do
                 merged_manifest_properties['cc'].store('renderer', { 'max_total_results' => 1000 })
@@ -605,6 +605,30 @@ module Bosh
               it 'does not render max_total_results into the ccng config' do
                 template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
                 expect(template_hash['renderer']).not_to have_key(:max_total_results)
+              end
+            end
+          end
+
+          describe 'legacy_md5_buildpack_paths_enabled' do
+            context 'when legacy md5 buildpack paths are enabled' do
+              before do
+                merged_manifest_properties['cc']['legacy_md5_buildpack_paths_enabled'] = true
+              end
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['legacy_md5_buildpack_paths_enabled']).to be(true)
+              end
+            end
+
+            context 'when legacy md5 buildpack paths are disabled' do
+              before do
+                merged_manifest_properties['cc']['legacy_md5_buildpack_paths_enabled'] = false
+              end
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['legacy_md5_buildpack_paths_enabled']).to be(false)
               end
             end
           end


### PR DESCRIPTION
Set default value to `true` to keep the current behaviour.

See also https://github.com/cloudfoundry/cloud_controller_ng/pull/3562.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
