### PR TITLE
Add dedicated config file for cc local workers

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -62,6 +62,7 @@ templates:
   db_ca.crt.erb: config/certs/db_ca.crt
   credhub_ca.crt.erb: config/certs/credhub_ca.crt
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
+  cloud_controller_local_worker_override.yml.erb: config/cloud_controller_local_worker_override.yml
 
 packages:
   - capi_utils
@@ -690,6 +691,8 @@ properties:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.max_connections_per_local_worker:
+    description: "Maximum database connections per cc local worker, if not set the ccng value is used (default)"
 
   uaa.cc.token_secret:
     description: "Symmetric secret used to decode uaa tokens."

--- a/jobs/cloud_controller_ng/templates/cloud_controller_local_worker_override.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_local_worker_override.yml.erb
@@ -1,0 +1,7 @@
+# This file is intended to override configurations for the cc local workers.
+# It will be merged with the cc_ng configuration file, and then cc_ng local workers will be started with the resulting configuration file.
+---
+<% if_p('ccdb.max_connections_per_local_worker') do |max_connections| %>
+db:
+  max_connections: <%= max_connections %>
+<% end %>

--- a/spec/cloud_controller_ng/cloud_controller_local_worker_override_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_local_worker_override_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh
+  module Template
+    module Test
+      describe 'cloud controller local worker override config template rendering' do
+        let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+        let(:release) { ReleaseDir.new(release_path) }
+        let(:job) { release.job('cloud_controller_ng') }
+
+        describe 'config/cloud_controller_local_worker_override.yml' do
+          let(:template) { job.template('config/cloud_controller_local_worker_override.yml') }
+          let(:manifest_properties) { {} }
+
+          it 'creates the cloud_controller_local_worker_override.yml config file' do
+            expect do
+              YAML.safe_load(template.render(manifest_properties, consumes: {}))
+            end.not_to raise_error
+          end
+
+          it 'renders a default empty file' do
+            template_hash = YAML.safe_load(template.render(manifest_properties, consumes: {}))
+            expect(template_hash).to be_nil
+          end
+
+          context 'when db max connections per local worker value is set' do
+            let(:manifest_properties) { { 'ccdb' => { 'max_connections_per_local_worker' => 10 } } }
+
+            it 'renders the values into the file' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: {}))
+              expect(template_hash['db']['max_connections']).to eq(10)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this PR, the same config file was used for both ccng and the (two) cc local workers. This dedicated file aims to decouple this bond and provide a way to override the configurations for cc local workers.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
