### PR TITLE
Add config attribute to override max_con for rotate-cc-database-key errand

### DIFF
--- a/jobs/rotate_cc_database_key/spec
+++ b/jobs/rotate_cc_database_key/spec
@@ -36,3 +36,5 @@ properties:
   cc.stdout_logging_enabled:
     default: true
     description: "Enable logging to stdout"
+  ccdb.max_connections:
+    description: "If provided, overrides ccdb.max_connections from cloud_controller_db link"

--- a/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
+++ b/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
@@ -63,7 +63,7 @@ db: &db
     user: <%= db_role["name"] %>
     password: <%= yaml_escape(db_role["password"]) %>
     database: <%= db["name"] %>
-  max_connections: <%= link("cloud_controller_db").p("ccdb.max_connections") %>
+  max_connections: <%= p("ccdb.max_connections", link("cloud_controller_db").p("ccdb.max_connections")) %>
   pool_timeout: <%= link("cloud_controller_db").p("ccdb.pool_timeout") %>
   log_level: "<%= p("cc.db_logging_level", link("cloud_controller_internal").p("cc.db_logging_level")) %>"
   log_db_queries: <%= p("cc.log_db_queries", link("cloud_controller_internal").p("cc.log_db_queries")) %>

--- a/spec/rotate_cc_database_key/rotate_cc_database_key_spec.rb
+++ b/spec/rotate_cc_database_key/rotate_cc_database_key_spec.rb
@@ -17,6 +17,9 @@ module Bosh
           {
             'cc' => {
               'db_logging_level' => 100
+            },
+            'ccdb' => {
+              'max_connections' => 100
             }
           }
         end
@@ -178,6 +181,24 @@ module Bosh
                                                                              'encryption_key_0' => 'blah',
                                                                              'encryption_key_1' => 'other_key'
                                                                            })
+              end
+            end
+          end
+
+          describe 'max_connections from cloud_controller_db' do
+            it 'overrides max_connections when value is set' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['db']['max_connections']).to eq(100)
+            end
+
+            context 'when max_connections is not overriden' do
+              before do
+                manifest_properties['ccdb'].delete('max_connections')
+              end
+
+              it 'sets the default value' do
+                template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+                expect(template_hash['db']['max_connections']).to eq('foo2')
               end
             end
           end


### PR DESCRIPTION
The rotate-cc-database-key errand inherits the max_connections settings from ccng. With this PR, we introduce a config attribute to override max_connections from the cloud_controller_db link.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
