### PR TITLE
Add config option to disable statsd metrics on api vms

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -220,6 +220,7 @@ provides:
   - uaa.clients.cc_routing.secret
   - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
+  - cc.experimental.disable_statsd_metrics
 
 consumes:
 - name: database
@@ -1200,6 +1201,11 @@ properties:
   cc.experimental.use_redis:
     description: "Use co-deployed Redis for rate limiting and metrics. If the Puma webserver is enabled, Redis will automatically be used."
     default: false
+
+  cc.experimental.disable_statsd_metrics:
+    description: "Use prometheus metrics, disable statsd metrics on api vms."
+    default: false
+
 
   cc.puma.workers:
     description: "Number of workers for Puma webserver."

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -205,6 +205,7 @@ provides:
   - cc.staging_upload_user
   - cc.statsd_host
   - cc.statsd_port
+  - cc.enable_statsd_metrics
   - cc.system_hostnames
   - cc.tls_port
   - cc.uaa.client_timeout
@@ -220,7 +221,6 @@ provides:
   - uaa.clients.cc_routing.secret
   - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
-  - cc.experimental.enable_statsd_metrics
 
 consumes:
 - name: database
@@ -981,6 +981,10 @@ properties:
     description: "The port for the statsd server, defaults to the local metron agent"
     default: 8125
 
+  cc.enable_statsd_metrics:
+    description: "Use statsd metrics on api vms."
+    default: true
+
   router.route_services_secret:
     description: "Support for route services is disabled when no value is configured."
     default: ""
@@ -1201,10 +1205,6 @@ properties:
   cc.experimental.use_redis:
     description: "Use co-deployed Redis for rate limiting and metrics. If the Puma webserver is enabled, Redis will automatically be used."
     default: false
-
-  cc.experimental.enable_statsd_metrics:
-    description: "Use statsd metrics on api vms."
-    default: true
 
   cc.puma.workers:
     description: "Number of workers for Puma webserver."

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -220,7 +220,7 @@ provides:
   - uaa.clients.cc_routing.secret
   - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
-  - cc.experimental.disable_statsd_metrics
+  - cc.experimental.enable_statsd_metrics
 
 consumes:
 - name: database
@@ -1202,10 +1202,9 @@ properties:
     description: "Use co-deployed Redis for rate limiting and metrics. If the Puma webserver is enabled, Redis will automatically be used."
     default: false
 
-  cc.experimental.disable_statsd_metrics:
-    description: "Use prometheus metrics, disable statsd metrics on api vms."
-    default: false
-
+  cc.experimental.enable_statsd_metrics:
+    description: "Use statsd metrics on api vms."
+    default: true
 
   cc.puma.workers:
     description: "Number of workers for Puma webserver."

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -433,7 +433,7 @@ allowed_cors_domains: <%= p("cc.allowed_cors_domains").to_json %>
 
 statsd_host: <%= p("cc.statsd_host") %>
 statsd_port: <%= p("cc.statsd_port") %>
-enable_statsd_metrics: <%= p("cc.experimental.enable_statsd_metrics") %>
+enable_statsd_metrics: <%= p("cc.enable_statsd_metrics") %>
 
 security_event_logging:
   enabled: <%= p("cc.security_event_logging.enabled") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -433,6 +433,7 @@ allowed_cors_domains: <%= p("cc.allowed_cors_domains").to_json %>
 
 statsd_host: <%= p("cc.statsd_host") %>
 statsd_port: <%= p("cc.statsd_port") %>
+disable_statsd_metrics: <%= p("cc.experimental.disable_statsd_metrics") %>
 
 security_event_logging:
   enabled: <%= p("cc.security_event_logging.enabled") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -433,7 +433,7 @@ allowed_cors_domains: <%= p("cc.allowed_cors_domains").to_json %>
 
 statsd_host: <%= p("cc.statsd_host") %>
 statsd_port: <%= p("cc.statsd_port") %>
-disable_statsd_metrics: <%= p("cc.experimental.disable_statsd_metrics") %>
+enable_statsd_metrics: <%= p("cc.experimental.enable_statsd_metrics") %>
 
 security_event_logging:
   enabled: <%= p("cc.security_event_logging.enabled") %>


### PR DESCRIPTION
When the `enable_statsd_metrics` configuration option is set to `false`, metrics on API VMs will be sent exclusively via Prometheus. The default behavior is `true`, where metrics are sent using both StatsD and Prometheus.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
