### PR TITLE
Add public TLS endpoint for blobstore

### DIFF
--- a/jobs/blobstore/spec
+++ b/jobs/blobstore/spec
@@ -12,6 +12,8 @@ templates:
   write_users.erb:      config/write_users
   blobstore.crt.erb:    ssl/blobstore.crt
   blobstore.key.erb:    ssl/blobstore.key
+  blobstore_public.crt.erb:    ssl/blobstore_public.crt
+  blobstore_public.key.erb:    ssl/blobstore_public.key
   pre-start.sh.erb:     bin/pre-start
   backup.erb:           bin/bbr/backup
   restore.erb:          bin/bbr/restore
@@ -52,6 +54,9 @@ properties:
   blobstore.port:
     description: TCP port on which the blobstore server (nginx) listens
     default: 8080
+  blobstore.public_tls_port:
+    description: TCP port on which the blobstore server (nginx) listens
+    default: 8081
   blobstore.tls.port:
     description: The TCP port on which the internal blobstore server listens
     default: 4443
@@ -61,6 +66,13 @@ properties:
 
   blobstore.tls.private_key:
     description: The PEM-encoded private key for signing TLS/SSL traffic
+
+  blobstore.public_tls.cert:
+    description: The PEM-encoded certificate (optionally as a certificate chain) for serving blobs over TLS/SSL
+
+  blobstore.public_tls.private_key:
+    description: The PEM-encoded private key for signing TLS/SSL traffic
+
 
   blobstore.admin_users:
     description: |

--- a/jobs/blobstore/templates/blobstore.conf.erb
+++ b/jobs/blobstore/templates/blobstore.conf.erb
@@ -1,10 +1,26 @@
-<% unless p('temporary_disable_non_tls_endpoints')  %>
 # Default server
+#
+
+<% unless p('temporary_disable_non_tls_endpoints')  %>
+
 server {
-  listen      <%= p("blobstore.port") %>;
+  listen      <%= p('blobstore.port') %>;
   return 404;
 }
-<% end  %>
+<% end %>
+
+server {
+  listen      <%= p('blobstore.public_tls_port') %> ssl;
+
+  ssl_certificate     /var/vcap/jobs/blobstore/ssl/blobstore_public.crt;
+  ssl_certificate_key /var/vcap/jobs/blobstore/ssl/blobstore_public.key;
+
+  ssl_ciphers DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+  ssl_protocols TLSv1.2;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+  return 404;
+}
 
 upstream blob_url_signer {
   server unix:/var/vcap/data/blobstore/signer.sock;
@@ -95,11 +111,15 @@ server {
   }
 }
 
-<% unless p('temporary_disable_non_tls_endpoints')  %>
 # Public server
+#
+
+<% unless p('temporary_disable_non_tls_endpoints')  %>
 server {
-  listen      <%= p('blobstore.port') %>;
   server_name blobstore.<%= p('system_domain') %>;
+
+  listen      <%= p('blobstore.port') %>;
+
   root        /var/vcap/store/shared/;
 
   access_log /var/vcap/sys/log/blobstore/public_access.log;
@@ -148,4 +168,66 @@ server {
     alias /var/vcap/store/shared/;
   }
 }
+
 <% end %>
+
+server {
+  listen      <%= p('blobstore.public_tls_port') %> ssl;
+  server_name blobstore.<%= p('system_domain') %>;
+
+  ssl_certificate     /var/vcap/jobs/blobstore/ssl/blobstore_public.crt;
+  ssl_certificate_key /var/vcap/jobs/blobstore/ssl/blobstore_public.key;
+
+  ssl_ciphers DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+  ssl_protocols TLSv1.2;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+
+  root        /var/vcap/store/shared/;
+
+  access_log /var/vcap/sys/log/blobstore/public_access.log;
+  error_log  /var/vcap/sys/log/blobstore/public_error.log;
+
+  # ensure the contents of this location block always match the internal server /read/ location block
+  location /read/ {
+    if ( $request_method !~ ^(GET|HEAD)$ ) {
+      return 405;
+    }
+
+    secure_link $arg_md5,$arg_expires;
+    secure_link_md5 "$secure_link_expires$uri <%= p('blobstore.secure_link.secret') %>";
+
+    if ($secure_link = "") {
+      return 403;
+    }
+
+    if ($secure_link = "0") {
+      return 410;
+    }
+
+    alias /var/vcap/store/shared/;
+  }
+
+  # ensure the contents of this location block always match the internal server /write/ location block
+  location /write/ {
+    dav_methods PUT;
+    create_full_put_path on;
+
+    if ( $request_method !~ ^(PUT)$ ) {
+      return 405;
+    }
+
+    secure_link $arg_md5,$arg_expires;
+    secure_link_md5 "$secure_link_expires$uri <%= p('blobstore.secure_link.secret') %>";
+
+    if ($secure_link = "") {
+      return 403;
+    }
+
+    if ($secure_link = "0") {
+      return 410;
+    }
+
+    alias /var/vcap/store/shared/;
+  }
+}

--- a/jobs/blobstore/templates/blobstore_public.crt.erb
+++ b/jobs/blobstore/templates/blobstore_public.crt.erb
@@ -1,0 +1,1 @@
+<%= p('blobstore.public_tls.cert') %>

--- a/jobs/blobstore/templates/blobstore_public.key.erb
+++ b/jobs/blobstore/templates/blobstore_public.key.erb
@@ -1,0 +1,1 @@
+<%= p('blobstore.public_tls.private_key') %>


### PR DESCRIPTION
Currently, the package and droplet download/upload endpoints redirect to the public port of the singleton-blobstore (if used) which does not support TLS.  This adds a TLS server to the singleton-blobstore's nginx conf. 

This change was designed to be consumed without any changes from a bosh manifest/cf-deployment.  That is, not supplying a SSL certificate in the manifest will simply cause the TLS server to not be render to the blobstore's nginx conf, and the download/upload endpoints will continue to redirect to the non-TLS port.  There will be a corresponding PR to cf-deployment soon, and some time after that is merged, we can remove the non-TLS ports entirely.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
