### PR TITLE
Introduce new config attribute for Puma

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1217,6 +1217,9 @@ properties:
     description: "Maximum number of threads per Puma webserver worker."
     default: 2
 
+  cc.puma.max_db_connections_per_process:
+    description: "Maximum database connections for Puma per process (main + Puma workers), if not set the ccng value is used (default)"
+
   cc.update_metric_tags_on_rename:
     description: "Enable sending a Desired LRP update when an app is renamed"
     default: true

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -57,6 +57,9 @@ webserver: <%= p("cc.experimental.use_puma_webserver") ? 'puma' : 'thin' %>
 puma:
   workers: <%= p("cc.puma.workers") %>
   max_threads: <%= p("cc.puma.max_threads") %>
+<% if_p("cc.puma.max_db_connections_per_process") do |max_db_conn_per_process| %>
+  max_db_connections_per_process: <%= max_db_conn_per_process %>
+<% end %>
 pid_filename: /var/vcap/data/cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: <%= !!properties.cc.newrelic.license_key || p("cc.development_mode") %>
 development_mode: <%= p("cc.development_mode") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -632,6 +632,26 @@ module Bosh
               end
             end
           end
+
+          describe 'max_db_connections_per_process' do
+            context "when 'cc.puma.max_db_connections_per_process' is set" do
+              before do
+                merged_manifest_properties['cc']['puma'] = { 'max_db_connections_per_process' => 10 }
+              end
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['puma']['max_db_connections_per_process']).to be(10)
+              end
+            end
+
+            context 'when cc.puma.max_db_connections_per_process is not set' do
+              it 'does not render max_db_connections_per_process into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['puma']).not_to have_key(:max_db_connections_per_process)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Currently, with Puma, all processes (i.e. main + Puma workers) is configured with the same cc db max_connections. This PR aims to introduce new config attribute (max_db_connections_per_process / optional). If not specified, the default db max_connections from cc_ng will be used.

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
