### PR TITLE
Add jemalloc package to missing job specs

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -32,6 +32,7 @@ packages:
   - capi_utils
   - cloud_controller_ng
   - libpq
+  - jemalloc
   - mariadb_connector_c
   - ruby-3.2
 

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -32,6 +32,7 @@ packages:
   - nginx
   - nginx_newrelic_plugin
   - libpq
+  - jemalloc
   - mariadb_connector_c
   - ruby-3.2
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -37,6 +37,7 @@ packages:
   - nginx
   - nginx_newrelic_plugin
   - libpq
+  - jemalloc
   - mariadb_connector_c
   - ruby-3.2
 

--- a/jobs/rotate_cc_database_key/spec
+++ b/jobs/rotate_cc_database_key/spec
@@ -14,6 +14,7 @@ packages:
   - capi_utils
   - cloud_controller_ng
   - libpq
+  - jemalloc
   - mariadb_connector_c
   - ruby-3.2
 

--- a/jobs/rotate_cc_database_key/templates/bin/run.erb
+++ b/jobs/rotate_cc_database_key/templates/bin/run.erb
@@ -2,6 +2,10 @@
 
 set -eu
 
+<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
+  export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
+
 rotate() {
   export CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/rotate_cc_database_key/config/cloud_controller_ng.yml
   source /var/vcap/jobs/rotate_cc_database_key/bin/ruby_version.sh


### PR DESCRIPTION
Some jobs consume the linked property `use_jemalloc_memory_allocator` to enable jemalloc but don't specify the required package in their spec file. Resulting in jemalloc not being used.
Thus the missing packages need be added.

Related to commit 62c5d07bb28e081bcdb21b4e2517fdd0158e6489/ PR #367 where we added experimental jemalloc support for all ccng based jobs.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
