### PR TITLE
Fix default frequency_in_seconds

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -125,7 +125,7 @@ properties:
     default: 30
   cc.failed_jobs.frequency_in_seconds:
     description: "How often the failed_jobs cleanup job runs"
-    default: 144000 # 4 hours
+    default: 14400 # 4 hours
 
   cc.external_protocol:
     default: "https"


### PR DESCRIPTION
4 * 60 * 60 = 14400, not 144000

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
