### PR TITLE
Add config for comma-delimited destinations in ASGs

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -975,6 +975,9 @@ properties:
     description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
   cc.default_staging_security_groups:
     description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+  cc.security_groups.enable_comma_delimited_destinations:
+    description: "Flag to enable comma-delimited destinations (e.g. `1.1.1.1,10.0.0.0/24`) within security group definitions. Defaults to `false`."
+    default: false
 
   cc.allowed_cors_domains:
     description: "List of domains (including scheme) from which Cross-Origin requests will be accepted, a * can be used as a wildcard for any part of a domain"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -433,6 +433,8 @@ log_audit_events: <%= p("cc.log_audit_events") %>
 security_group_definitions: <%= p("cc.security_group_definitions").to_json %>
 default_running_security_groups: <%= p("cc.default_running_security_groups").to_json %>
 default_staging_security_groups: <%= p("cc.default_staging_security_groups").to_json %>
+security_groups:
+  enable_comma_delimited_destinations: <%= p("cc.security_groups.enable_comma_delimited_destinations") %>
 
 allowed_cors_domains: <%= p("cc.allowed_cors_domains").to_json %>
 


### PR DESCRIPTION
### A short explanation of the proposed change:

Allow operators to configure Cloud Controller to support ASGs with comma-delimited destinations.
For example, the following ASG definition would be valid:

```
[
 {
   "protocol": "tcp",
   "destination": "1.2.3.4,10.0.0.0/24,25.0.0.0-26.0.0.0",
   "ports": "65432",
   "description": "Valid comma delimited list of destinations"
 }
]
```


### An explanation of the use cases your change solves

Currently, if a developer wants to open connections from their cf app to two non-consecutive IP addresses (e.g. 8.8.8.8 and 10.10.10.10), they'd have to create two separate ASGs. This creates duplication and performance implications on some large environments with many ASGs that are also running networking fabrics _other_ than silk.

One way to reduce said duplication is to enable comma-delimited destinations, so that the firewall rules are consolidated.

### Links

- https://github.com/cloudfoundry/capi-release/pull/386
- https://github.com/cloudfoundry/cloud_controller_ng/pull/3644
- https://github.com/cloudfoundry/silk-release/pull/107

- [#186770494](https://www.pivotaltracker.com/story/show/186770494)

##### Checklist
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)