### PR TITLE
Add `max_migration_statement_runtime_in_seconds` config property

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -690,6 +690,9 @@ properties:
   ccdb.max_migration_duration_in_minutes:
     description: "the maximum time migrations should be allowed to run before job startup should error"
     default: 20160
+  ccdb.max_migration_statement_runtime_in_seconds:
+    description: "effective for postgres only. The maximum time a statement is executed before it being canceled server side(by the DB). This prevents expensive and long running migrations that block normal operation of the Cloud Controller by canceling misbehaving migrations. An operator can decide to increase or decrease this time."
+    default: 30
   ccdb.connection_expiration_timeout:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -216,6 +216,7 @@ db: &db
 <% uaa_url = p("uaa.url", "#{scheme}://uaa.#{system_domain}")
    login_url = p("login.url", "#{scheme}://login.#{system_domain}") %>
 max_migration_duration_in_minutes: <%= p("ccdb.max_migration_duration_in_minutes") %>
+max_migration_statement_runtime_in_seconds: <%= p("ccdb.max_migration_statement_runtime_in_seconds") %>
 login:
   url: <%= p("login.enabled") ? login_url : uaa_url %>
 uaa:


### PR DESCRIPTION
This change enables operators to configure
the new config property `max_migration_statement_runtime_in_seconds` see https://github.com/cloudfoundry/cloud_controller_ng/pull/3633.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
