### PR TITLE
Remove "nginx" from response headers and error responses

### DIFF
--- a/jobs/blobstore/templates/nginx.conf.erb
+++ b/jobs/blobstore/templates/nginx.conf.erb
@@ -19,6 +19,7 @@ http {
 
   access_log	  /var/vcap/sys/log/blobstore/access.log timed_combined;
   server_tokens off;
+  more_clear_headers Server;
 
   client_body_temp_path /var/vcap/data/blobstore/tmp/client_body_temp;
   proxy_temp_path /var/vcap/data/blobstore/tmp/proxy_temp;

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -15,6 +15,7 @@ http {
   include       mime.types;
   default_type  text/html;
   server_tokens off;
+  more_clear_headers Server;
 
   log_format main escape=<%= p("cc.nginx_access_log_escaping") %> '<%= p("cc.nginx_access_log_format").chomp %>';
 

--- a/jobs/cloud_controller_ng/templates/nginx_maintenance.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx_maintenance.conf.erb
@@ -17,6 +17,7 @@ http {
   include       mime.types;
   default_type  text/html;
   server_tokens off;
+  more_clear_headers Server;
 
   client_body_temp_path /var/vcap/data/cloud_controller_ng/tmp/client_body_temp;
   proxy_temp_path       /var/vcap/data/cloud_controller_ng/tmp/proxy_temp;

--- a/packages/nginx/README.md
+++ b/packages/nginx/README.md
@@ -9,3 +9,4 @@ The files can be downloaded from the following locations:
 | nginx-1.25.2.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.25.2.tar.gz)                                                       |
 | nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz) 
 | pcre-8.45.tar.gz | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz)                               |
+|headers-more-nginx-module-0.37.tar.gz| [github.com/openresty/headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module/archive/refs/tags/v0.37.tar.gz) |

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -6,6 +6,9 @@ tar xzvf nginx/pcre-8.45.tar.gz
 echo "Extracting nginx_upload module..."
 tar xzvf nginx/nginx-upload-module-2.3.0.tar.gz
 
+echo "Extracting headers-more-nginx-module "
+tar xzvf nginx/headers-more-nginx-module-0.37.tar.gz
+
 echo "Patching upload module"
 pushd nginx-upload-module-2.3.0
   #patch < ../nginx/upload_module_new_nginx_support.patch
@@ -17,10 +20,12 @@ tar xzvf nginx/nginx-1.25.2.tar.gz
 
 echo "Building nginx..."
 pushd nginx-1.25.2
+  sed -i 's@<hr><center>nginx</center>@@g' src/http/ngx_http_special_response.c 
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.45 \
     --add-module=../nginx-upload-module-2.3.0 \
+    --add-module=../headers-more-nginx-module-0.37 \
     --with-http_stub_status_module \
     --with-http_ssl_module
 

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -6,3 +6,4 @@ files:
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch
 - nginx/upload_module_new_nginx_support.patch
+- nginx/headers-more-nginx-module-0.37.tar.gz

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -20,8 +20,12 @@ tar xzvf nginx/nginx-1.25.2.tar.gz
 echo "Extracting webdav extensions"
 tar xzvf nginx/nginx-dav-ext-module-3.0.0.tar.gz
 
+echo "Extracting headers-more-nginx-module "
+tar xzvf nginx/headers-more-nginx-module-0.37.tar.gz
+
 echo "Building nginx..."
 pushd nginx-1.25.2
+  sed -i 's@<hr><center>nginx</center>@@g' src/http/ngx_http_special_response.c
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \
@@ -30,7 +34,8 @@ pushd nginx-1.25.2
     --with-http_dav_module \
     --with-http_secure_link_module \
     --with-http_ssl_module \
-    --add-module=../nginx-dav-ext-module-3.0.0
+    --add-module=../nginx-dav-ext-module-3.0.0 \
+    --add-module=../headers-more-nginx-module-0.37
 
   make
   make install

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -5,3 +5,4 @@ files:
   - nginx/nginx-1.25.2.tar.gz
   - nginx/pcre-8.45.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz
+  - nginx/headers-more-nginx-module-0.37.tar.gz


### PR DESCRIPTION
Server name (Nginx) is leaked in the header and in the body of an error messages. This is to clear compliance findings.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
