### PR TITLE
Make number of db migration retries configurable

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -399,6 +399,9 @@ properties:
   cc.run_prestart_migrations:
     description: "Run Cloud Controller DB migrations in BOSH pre-start script. Should be changed to false for deployments where the PostgreSQL job is deployed to the same VM as Cloud Controller. Otherwise, the default of true is preferable."
     default: true
+  cc.migration_max_retries:
+    description: "Number of retries for database migrations, defaults to 3"
+    default: 3
 
   cc.uaa_resource_id:
     default: "cloud_controller,cloud_controller_service_permissions"

--- a/jobs/cloud_controller_ng/templates/migrate_db.sh.erb
+++ b/jobs/cloud_controller_ng/templates/migrate_db.sh.erb
@@ -14,7 +14,7 @@ function migrate {
     echo "Running migrations"
     local result=1
     local counter=1
-    local num_retries=3
+    local num_retries=<%= p("cc.migration_max_retries") %>
     while [[ $counter -le $num_retries ]]; do
       echo "Running migration try number ${counter} of ${num_retries}"
       bundle exec rake db:migrate


### PR DESCRIPTION
The number of database migrations retries should be configurable for operators. The default remains the same with 3.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
