### PR TITLE
Add optional parameter to set postgres worker mem for db migrations

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -699,6 +699,8 @@ properties:
   ccdb.max_migration_statement_runtime_in_seconds:
     description: "effective for postgres only. The maximum time a statement is executed before it being canceled server side(by the DB). This prevents expensive and long running migrations that block normal operation of the Cloud Controller by canceling misbehaving migrations. An operator can decide to increase or decrease this time."
     default: 30
+  ccdb.migration_psql_worker_memory_kb:
+    description: "Allows operators to set the worker memory for PostgreSQL database migrations"
   ccdb.connection_expiration_timeout:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -211,6 +211,9 @@ db: &db
 <% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
   connection_expiration_random_delay: <%= expiration_delay %>
 <% end %>
+<% if_p("ccdb.migration_psql_worker_memory_kb") do |psql_worker_memory_kb| %>
+  migration_psql_worker_memory_kb: <%= psql_worker_memory_kb %>
+<% end %>
 
 <% scheme = p("login.protocol")
    system_domain = p("system_domain") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -670,6 +670,26 @@ module Bosh
               end
             end
           end
+
+          describe 'migration_psql_worker_memory_kb' do
+            context "when 'ccdb.migration_psql_worker_memory_kb' is present" do
+              before do
+                merged_manifest_properties['ccdb']['migration_psql_worker_memory_kb'] = 1234
+              end
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['db']['migration_psql_worker_memory_kb']).to eq(1234)
+              end
+            end
+
+            context "when 'ccdb.migration_psql_worker_memory_kb' is not present" do
+              it 'does not render migration_psql_worker_memory_kb into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['db']).not_to have_key(:migration_psql_worker_memory_kb)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Add optional parameter to set postgres worker mem for db migrations.

* Links to any other associated PRs
- https://github.com/cloudfoundry/cloud_controller_ng/pull/3738

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
