### PR TITLE
Remove nginx from response headers and error responses

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -15,6 +15,11 @@ popd
 echo "Extracting nginx..."
 tar xzvf nginx/nginx-1.25.2.tar.gz
 
+sed -i 's@"nginx/"@"-/"@g' nginx-1.25.2/src/core/nginx.h
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/ngx_http_header_filter_module.c
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/v2/ngx_http_v2_filter_module.c
+sed -i 's@<hr><center>nginx</center>@@g' nginx-1.25.2/src/http/ngx_http_special_response.c
+
 echo "Building nginx..."
 pushd nginx-1.25.2
   ./configure \

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -20,6 +20,11 @@ tar xzvf nginx/nginx-1.25.2.tar.gz
 echo "Extracting webdav extensions"
 tar xzvf nginx/nginx-dav-ext-module-3.0.0.tar.gz
 
+sed -i 's@"nginx/"@"-/"@g' nginx-1.25.2/src/core/nginx.h
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/ngx_http_header_filter_module.c
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/v2/ngx_http_v2_filter_module.c
+sed -i 's@<hr><center>nginx</center>@@g' nginx-1.25.2/src/http/ngx_http_special_response.c
+
 echo "Building nginx..."
 pushd nginx-1.25.2
   ./configure \


### PR DESCRIPTION
We observed that the server name (Nginx) is leaked in the header and in the body of an error message.

To bolster the security stance of the web application and reduce the likelihood of information exposure, it's highly advised to refrain from divulging the server's name and version in any response data, including error messages.

What the PR changes: adjust NGINX sources by using sed to perform an in-place substitution of the server name before building nginx (Found by @philippthun [here](https://medium.com/@getpagespeed/how-to-remove-the-server-header-in-nginx-e74c7b431b))

With this change the server name does not appear any more in any response/error message.


* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
