### PR TITLE
New config parameter for cleanup job

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -127,6 +127,10 @@ properties:
     description: "How often the failed_jobs cleanup job runs"
     default: 14400 # 4 hours
 
+  cc.service_operations_initial_cleanup.frequency_in_seconds:
+    description: "How often operations stuck in state 'create'/'initial' should be cleaned up."
+    default: 300 # 5 minutes
+
   cc.external_protocol:
     default: "https"
     description: "The protocol used to access the CC API from an external entity"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -90,6 +90,9 @@ failed_jobs:
   <% end %>
   frequency_in_seconds: <%= p("cc.failed_jobs.frequency_in_seconds") %>
 
+service_operations_initial_cleanup:
+  frequency_in_seconds: <%= p("cc.service_operations_initial_cleanup.frequency_in_seconds") %>
+
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>
 


### PR DESCRIPTION
* A short explanation of the proposed change:

New config property `service_operations_initial_cleanup.frequency_in_seconds` for the background cleanup job.

* An explanation of the use cases your change solves

The background job cleans up operations stuck in state 'create'/'initial' (sets them to 'failed' so that users can delete the associated entity).

* Links to any other associated PRs

https://github.com/cloudfoundry/cloud_controller_ng/pull/3742

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
