### PR TITLE
Introduce parameter `migration_psql_concurrent_statement_timeout_in_seconds`

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -704,6 +704,9 @@ properties:
   ccdb.max_migration_statement_runtime_in_seconds:
     description: "effective for postgres only. The maximum time a statement is executed before it being canceled server side(by the DB). This prevents expensive and long running migrations that block normal operation of the Cloud Controller by canceling misbehaving migrations. An operator can decide to increase or decrease this time."
     default: 30
+  ccdb.migration_psql_concurrent_statement_timeout_in_seconds:
+    description: "effective for postgres only. The maximum time concurrent statements (e.g. 'CREATE INDEX ... CONCURRENTLY') are executed before it being canceled server side(by the DB). An operator can decide to increase or decrease this time. Concurrent statements might need longer than the default 'max_migration_statement_runtime_in_seconds' timeout as they don't use locking mechanisms."
+    default: 1800
   ccdb.migration_psql_worker_memory_kb:
     description: "Allows operators to set the worker memory for PostgreSQL database migrations"
   ccdb.connection_expiration_timeout:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -223,6 +223,7 @@ db: &db
    login_url = p("login.url", "#{scheme}://login.#{system_domain}") %>
 max_migration_duration_in_minutes: <%= p("ccdb.max_migration_duration_in_minutes") %>
 max_migration_statement_runtime_in_seconds: <%= p("ccdb.max_migration_statement_runtime_in_seconds") %>
+migration_psql_concurrent_statement_timeout_in_seconds: <%= p("ccdb.migration_psql_concurrent_statement_timeout_in_seconds") %>
 login:
   url: <%= p("login.enabled") ? login_url : uaa_url %>
 uaa:


### PR DESCRIPTION
Operators would like to configure the optional ccng config property `migration_psql_concurrent_statement_timeout_in_seconds`

Related to https://github.com/cloudfoundry/cloud_controller_ng/pull/3772


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
