### PR TITLE
Bump libpq to v16.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -90,10 +90,10 @@ nginx/pcre-8.45.tar.gz:
   size: 2096552
   object_id: a90f9f20-e23b-4755-59c7-101197325dab
   sha: sha256:4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09
-postgres/postgresql-11.22.tar.gz:
-  size: 26826810
-  object_id: d1f8d34c-b438-44e7-7672-5daea8a6da66
-  sha: sha256:6445a4e1533c1e8bb616d4a3784bdc4c0226b541f6f0c8d996d9f27d581d49c3
+postgres/postgresql-16.2.tar.gz:
+  size: 32558575
+  object_id: 65444a18-d984-4995-49d1-65156577e6e1
+  sha: sha256:2b8201047ec81acd1bad29dba278d788e7891b9c3e8232eda16bb29dec8131c7
 redis/7.2.4.tar.gz:
   size: 3424319
   object_id: c4584e2d-c65c-4f74-782d-deb2cffddd07

--- a/packages/libpq/README.md
+++ b/packages/libpq/README.md
@@ -6,4 +6,4 @@ This file can be downloaded from the following locations:
 
 | Filename                | Download URL |
 |-------------------------| ------------ |
-| postgresql-11.22.tar.gz | https://ftp.postgresql.org/pub/source/v11.22/postgresql-11.22.tar.gz |
+| postgresql-16.2.tar.gz | https://ftp.postgresql.org/pub/source/v16.2/postgresql-16.2.tar.gz |

--- a/packages/libpq/packaging
+++ b/packages/libpq/packaging
@@ -2,7 +2,7 @@
 
 function main() {
   local pgversion
-  pgversion="postgresql-11.22"
+  pgversion="postgresql-16.2"
 
   tar xzf "postgres/${pgversion}.tar.gz"
 

--- a/packages/libpq/spec
+++ b/packages/libpq/spec
@@ -1,4 +1,4 @@
 ---
 name: libpq
 files:
-- postgres/postgresql-11.22.tar.gz
+- postgres/postgresql-16.2.tar.gz


### PR DESCRIPTION
Bump libpq to v16.2

Postgres 16 is the default in cf-deployment: https://github.com/cloudfoundry/cf-deployment/commit/137a99e0443e239184d00861953d078167a97a76

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
