### PR TITLE
Revert "Bump libpq to v16.2"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -90,10 +90,10 @@ nginx/pcre-8.45.tar.gz:
   size: 2096552
   object_id: a90f9f20-e23b-4755-59c7-101197325dab
   sha: sha256:4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09
-postgres/postgresql-16.2.tar.gz:
-  size: 32558575
-  object_id: 65444a18-d984-4995-49d1-65156577e6e1
-  sha: sha256:2b8201047ec81acd1bad29dba278d788e7891b9c3e8232eda16bb29dec8131c7
+postgres/postgresql-11.22.tar.gz:
+  size: 26826810
+  object_id: d1f8d34c-b438-44e7-7672-5daea8a6da66
+  sha: sha256:6445a4e1533c1e8bb616d4a3784bdc4c0226b541f6f0c8d996d9f27d581d49c3
 redis/7.2.4.tar.gz:
   size: 3424319
   object_id: c4584e2d-c65c-4f74-782d-deb2cffddd07

--- a/packages/libpq/README.md
+++ b/packages/libpq/README.md
@@ -6,4 +6,4 @@ This file can be downloaded from the following locations:
 
 | Filename                | Download URL |
 |-------------------------| ------------ |
-| postgresql-16.2.tar.gz | https://ftp.postgresql.org/pub/source/v16.2/postgresql-16.2.tar.gz |
+| postgresql-11.22.tar.gz | https://ftp.postgresql.org/pub/source/v11.22/postgresql-11.22.tar.gz |

--- a/packages/libpq/packaging
+++ b/packages/libpq/packaging
@@ -2,7 +2,7 @@
 
 function main() {
   local pgversion
-  pgversion="postgresql-16.2"
+  pgversion="postgresql-11.22"
 
   tar xzf "postgres/${pgversion}.tar.gz"
 

--- a/packages/libpq/spec
+++ b/packages/libpq/spec
@@ -1,4 +1,4 @@
 ---
 name: libpq
 files:
-- postgres/postgresql-16.2.tar.gz
+- postgres/postgresql-11.22.tar.gz


### PR DESCRIPTION
Reverts cloudfoundry/capi-release#412

Causes the following error
```
current directory:
/var/vcap/data/packages/cloud_controller_ng/e4309d5ef67b05d0181763ebed3160337ec9124c/gem_home/ruby/3.2.0/gems/pg-1.5.6/ext
/var/vcap/data/packages/ruby-3.2/8499836d9f90fe8b9742c5b321b88ef90a166d3a/bin/ruby
extconf.rb --with-pg-lib\=/var/vcap/packages/libpq/lib
--with-pg-include\=/var/vcap/packages/libpq/include
Calling libpq with GVL unlocked
checking for pg_config... no
checking for libpq per pkg-config... no
Using libpq from /var/vcap/packages/libpq/lib
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*****************************************************************************

Unable to find PostgreSQL client library.
```