### PR TITLE
Default legacy_md5_buildpack_paths_enabled to false

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1256,4 +1256,4 @@ properties:
 
   cc.legacy_md5_buildpack_paths_enabled:
     description: "Enable legacy MD5 buildpack paths. If disabled, xxhash64 is used for calculating paths in buildpack image layers."
-    default: true
+    default: false


### PR DESCRIPTION
The default value for this property is `false` in cf-deployment since v40.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
