### PR TITLE
Add new rubocops to .rubocop.yml

### DIFF
--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -13,6 +13,9 @@ FactoryBot/AssociationStyle: # new in 2.23
 FactoryBot/ConsistentParenthesesStyle:
   Enabled: true
 
+FactoryBot/ExcessiveCreateList: # new in 2.25
+  Enabled: true
+
 FactoryBot/FactoryNameStyle:
   Enabled: true
 
@@ -175,6 +178,9 @@ Style/IfUnlessModifier:
 Style/Lambda:
   Enabled: true
 
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+
 Style/MultilineBlockChain:
   Enabled: true
 
@@ -208,6 +214,9 @@ Style/RescueModifier:
 Style/SafeNavigation:
   Enabled: true
 
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+
 Style/SignalException:
   Enabled: true
 
@@ -215,6 +224,9 @@ Style/SingleLineBlockParams:
   Enabled: true
 
 Style/StructInheritance:
+  Enabled: true
+
+Style/SuperArguments: # new in 1.64
   Enabled: true
 
 Style/SymbolArray:
@@ -535,6 +547,9 @@ Capybara/MatchStyle:
 Capybara/NegationMatcher:
   Enabled: true
 
+Capybara/RedundantWithinFind: # new in 2.20
+  Enabled: true
+
 Capybara/RSpec/HaveSelector: # new in 2.19
   Enabled: true
 
@@ -571,16 +586,25 @@ RSpec/DuplicatedMetadata:
 RSpec/EmptyMetadata: # new in 2.24
   Enabled: true
 
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+
 RSpec/Eq: # new in 2.24
   Enabled: true
 
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 
+RSpec/ExpectInLet: # new in 2.30
+  Enabled: true
+
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
 
 RSpec/IndexedLet: # new in 2.20
+  Enabled: true
+
+RSpec/IsExpectedSpecify: # new in 2.27
   Enabled: true
 
 RSpec/MatchArray: # new in 2.19
@@ -601,6 +625,15 @@ RSpec/ReceiveMessages: # new in 2.23
 RSpec/RedundantAround: # new in 2.19
   Enabled: true
 
+RSpec/RedundantPredicateMatcher: # new in 2.26
+  Enabled: true
+
+RSpec/RemoveConst: # new in 2.26
+  Enabled: true
+
+RSpec/RepeatedSubjectCall: # new in 2.27
+  Enabled: true
+
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
 
@@ -616,25 +649,28 @@ RSpec/SpecFilePathSuffix: # new in 2.24
 RSpec/SubjectDeclaration:
   Enabled: true
 
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
+  Enabled: true
+
 RSpec/VerifiedDoubleReference:
   Enabled: true
 
-RSpec/Rails/AvoidSetupHook:
+RSpecRails/AvoidSetupHook:
   Enabled: true
 
-RSpec/Rails/HaveHttpStatus:
+RSpecRails/HaveHttpStatus:
   Enabled: true
 
-RSpec/Rails/InferredSpecType:
+RSpecRails/InferredSpecType:
   Enabled: true
 
-RSpec/Rails/MinitestAssertions:
+RSpecRails/MinitestAssertions:
   Enabled: true
 
-RSpec/Rails/NegationBeValid: # new in 2.23
+RSpecRails/NegationBeValid: # new in 2.23
   Enabled: true
 
-RSpec/Rails/TravelAround: # new in 2.19
+RSpecRails/TravelAround: # new in 2.19
   Enabled: true
 
 RSpec/MultipleMemoizedHelpers:


### PR DESCRIPTION
- removes warning that rubocops aren't enabled
- if ccng gets them, why not capi release?

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
