### PR TITLE
Update prom_scraper_config to add origin: cc label

### DIFF
--- a/jobs/cloud_controller_ng/templates/prom_scraper_config.yml.erb
+++ b/jobs/cloud_controller_ng/templates/prom_scraper_config.yml.erb
@@ -5,4 +5,6 @@ instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: <%= p("cc.internal_service_hostname") %>
 path: /internal/v4/metrics
+labels:
+  origin: cc
 <% end -%>


### PR DESCRIPTION
Resolves https://github.com/cloudfoundry/cloud_controller_ng/issues/3842 

This add the `origin: cc` label to every prom metric emitted by cc.

Before:
```
origin:"" eventType:ValueMetric timestamp:1716927345188339944 deployment:"cf-593c65d5b217b0a112ad" job:"control" index:"66379c89-3e02-4322-9555-004ce8183ea5" ip:"10.0.4.7" tags:<key:"instance_id" value:"66379c89-3e02-4322-9555-004ce8183ea5" > tags:<key:"product" value:"Small Footprint VMware Tanzu Application Service" > tags:<key:"source_id" value:"cloud_controller_ng" > tags:<key:"system_domain" value:"xxx" > valueMetric:<name:"cc_requests_outstanding_total" value:1 unit:"" >
```

After:
```
origin:"cc" eventType:ValueMetric timestamp:1718239416878685187 deployment:"cf-a31da169de4fe97cda42" job:"cloud_controller" index:"27c6545a-6ca1-4dc1-acb6-70e5ce5e7893" ip:"10.0.4.12" tags:<key:"instance_id" value:"27c6545a-6ca1-4dc1-acb6-70e5ce5e7893" > tags:<key:"product" value:"VMware Tanzu Application Service" > tags:<key:"source_id" value:"cloud_controller_ng" > tags:<key:"system_domain" value:"xxx" > valueMetric:<name:"cc_requests_outstanding_total" value:1 unit:"" >
```

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
