### PR TITLE
Add info on how the format of the version number of the min cf cli version should be configured

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -395,7 +395,7 @@ properties:
     description: "Show warning message if CF CLI version is below minimum."
     default: false
   cc.min_cli_version:
-    description: "Minimum version of the CF CLI to work with the API."
+    description: "Minimum version of the CF CLI to work with the API. Version number format: 3 groups of digits separated by '.' e.g. 8.0.0"
     default: ~
   cc.min_recommended_cli_version:
     description: "Minimum recommended version of the CF CLI."


### PR DESCRIPTION
Add info on how the format of the version number of the min cf cli version should be configured
* A short explanation of the proposed change:
Description enhancement
* An explanation of the use cases your change solves
User can read in config description how to format cf cli version number

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
