### PR TITLE
Trigger deploying V2 docs

### DIFF
--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -24,13 +24,8 @@ jobs:
           # Set the required variables
           target_repo="pivotalgeorge/cloud_controller_ng"
           target_ref="gh-pages"
-          #version="${{ github.event.inputs.target_version }}"
-          version=7
           target_workflow="gh_pages_docs_v2.yml"
   
-          request_body="{\"ref\": \"${target_ref}\", \"inputs\": {\"version\": \"${version}\"}}"
-          echo -d "${request_body}"
-
           # show any error and exit nonzero
           curl --silent --fail-with-body --show-error -L \
             -X POST \
@@ -38,5 +33,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CCNG_USER_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${target_repo}/actions/workflows/${target_workflow}/dispatches \
-            -d '{"ref":"gh-pages","inputs":{"name":"Mona the Octocat","home":"San Francisco, CA"}}'
-          # -d "${request_body}"
+            -d "{\"ref\": \"${target_ref}\"}"

--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -28,7 +28,8 @@ jobs:
           version=7
           target_workflow="gh_pages_docs_v2.yml"
   
-          curl -L \
+          # show any error and exit nonzero
+          curl --silent --fail-with-body --show-error -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.CCNG_USER_TOKEN }}" \

--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -38,4 +38,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CCNG_USER_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${target_repo}/actions/workflows/${target_workflow}/dispatches \
-            -d "${request_body}"
+            -d '{"ref":"gh-pages","inputs":{"name":"Mona the Octocat","home":"San Francisco, CA"}}'
+          # -d "${request_body}"

--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -28,6 +28,9 @@ jobs:
           version=7
           target_workflow="gh_pages_docs_v2.yml"
   
+          request_body="{\"ref\": \"${target_ref}\", \"inputs\": {\"version\": \"${version}\"}}"
+          echo -d "${request_body}"
+
           # show any error and exit nonzero
           curl --silent --fail-with-body --show-error -L \
             -X POST \
@@ -35,4 +38,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CCNG_USER_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${target_repo}/actions/workflows/${target_workflow}/dispatches \
-            -d "{\"ref\": \"${target_ref}\", \"inputs\": {\"version\": \"${version}\"}}"
+            -d "${request_body}"

--- a/.github/workflows/trigger-docs.yml
+++ b/.github/workflows/trigger-docs.yml
@@ -1,0 +1,37 @@
+# Workflow to trigger building docs in CCNG
+# since capi-release is the repo with GitHub Releases and corresponding tags
+# inspired by: https://medium.com/hostspaceng/triggering-workflows-in-another-repository-with-github-actions-4f581f8e0ceb
+# docs: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+
+name: Trigger CCNG docs workflow
+
+on:
+  # TODO add correct trigger on tags / releases
+  push:
+    branches:
+    - develop
+    - trigger-docs
+  # allow manual run
+  workflow_dispatch:
+
+jobs:
+  trigger-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger v2 docs build
+        run: |
+          # Set the required variables
+          target_repo="pivotalgeorge/cloud_controller_ng"
+          target_ref="gh-pages"
+          #version="${{ github.event.inputs.target_version }}"
+          version=7
+          target_workflow="gh_pages_docs_v2.yml"
+  
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.CCNG_USER_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${target_repo}/actions/workflows/${target_workflow}/dispatches \
+            -d "{\"ref\": \"${target_ref}\", \"inputs\": {\"version\": \"${version}\"}}"


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: An Actions Workflow to trigger rebuilding docs

* An explanation of the use cases your change solves
This addresses the concern in discussion on https://github.com/cloudfoundry/cloud_controller_ng/pull/3874 about the v2 GitHub Actions workflow not being directly triggered by new CAPI tags/releases

* Links to any other associated PRs
see CCNG#3874 above

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
N/A - no code changes to the release / anything that would be covered by CATS - this is a new Workflow file
