### PR TITLE
GitHub Pages V2 Docs

### DIFF
--- a/.github/workflows/gh_pages_docs_v2.yml
+++ b/.github/workflows/gh_pages_docs_v2.yml
@@ -40,7 +40,10 @@ jobs:
       uses: actions/configure-pages@v5
     - name: Render index template
       working-directory: cloud_controller_ng/docs/v2
-      run: ./render.sh
+      run: |
+        pwd
+        ls
+        ./render.sh
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/gh_pages_docs_v2.yml
+++ b/.github/workflows/gh_pages_docs_v2.yml
@@ -1,0 +1,63 @@
+name: Deploy V2 Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+    - main
+    - gh-pages-v2-docs
+  # Allow manual workflow run
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  push-v2:
+    runs-on: ubuntu-latest
+    # defaults:
+    #   run:
+    #     working-directory: cloud_controller_ng/docs/v2
+    steps:
+    - name: Checkout this repo
+      uses: actions/checkout@v4
+      with:
+        path: capi-release
+    - name: Checkout CCNG
+      uses: actions/checkout@v4
+      with:
+        repository: cloudfoundry/cloud_controller_ng
+        path: cloud_controller_ng
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Render index template
+      working-directory: cloud_controller_ng/docs/v2
+      run: ./render.sh
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: cloud_controller_ng/docs/v2
+
+  # Deployment job
+  deploy:
+    runs-on: ubuntu-latest
+    needs: push-v2
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    defaults:
+      run:
+        working-directory: ./docs/v3
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+

--- a/.github/workflows/gh_pages_docs_v2.yml
+++ b/.github/workflows/gh_pages_docs_v2.yml
@@ -34,8 +34,7 @@ jobs:
     - name: Checkout CCNG
       uses: actions/checkout@v4
       with:
-        repository: pivotalgeorge/cloud_controller_ng
-        ref: gh-pages
+        repository: cloudfoundry/cloud_controller_ng
         path: cloud_controller_ng
     - name: Setup Pages
       uses: actions/configure-pages@v5

--- a/.github/workflows/gh_pages_docs_v2.yml
+++ b/.github/workflows/gh_pages_docs_v2.yml
@@ -34,7 +34,8 @@ jobs:
     - name: Checkout CCNG
       uses: actions/checkout@v4
       with:
-        repository: cloudfoundry/cloud_controller_ng
+        repository: pivotalgeorge/cloud_controller_ng
+        ref: gh-pages
         path: cloud_controller_ng
     - name: Setup Pages
       uses: actions/configure-pages@v5

--- a/.github/workflows/gh_pages_docs_v2.yml
+++ b/.github/workflows/gh_pages_docs_v2.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - gh-pages-v2-docs
   # Allow manual workflow run
   workflow_dispatch:
 
@@ -23,9 +22,6 @@ concurrency:
 jobs:
   push-v2:
     runs-on: ubuntu-latest
-    # defaults:
-    #   run:
-    #     working-directory: cloud_controller_ng/docs/v2
     steps:
     - name: Checkout this repo
       uses: actions/checkout@v4


### PR DESCRIPTION
This is a move of [CCNG PR #3874](https://github.com/cloudfoundry/cloud_controller_ng/pull/3874)

- The original location was unsatisfactory since there is already a GitHub Pages site bound to the CCNG repo.
- Detail from the original PR, copied for convenience:
  - Serve the V2 API docs as static GitHub Pages assets, deployed via GitHub Actions
  - As part of the VMware->Broadcom migration, the infrastructure hosting the current v2 apidocs is being replaced. This provides an opportunity to sunset unneeded apps, lowering the project's maintenance & support burden.


_Links to any other associated PRs_
https://github.com/cloudfoundry/cloud_controller_ng/pull/3874 - as above
https://github.com/cloudfoundry/capi-release/pull/438 - going to be closed since the trigger direction will be reversed with the v2 pages workflow living under capi-release

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
N/A - no code changes to the release / anything that would be covered by CATS - this is a new Workflow file