### PR TITLE
Add CNAME for V2 docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+apidocs.cloudfoundry.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-apidocs.cloudfoundry.org
+v2-apidocs.cloudfoundry.org


### PR DESCRIPTION
This PR is needed to configure a custom domain for the V2 docs' GitHub Pages, as per [Configuring a subdomain in the Pages docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain)
The Pages site is currently pushed to the default for this repository, https://cloudfoundry.github.io/capi-release/

Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/440

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
N/A - no code changes to the release / anything that would be covered by CATS - this is a `CNAME` file
