### PR TITLE
Add app_log_revision property

### DIFF
--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -275,3 +275,5 @@ max_annotations_per_resource: <%= link("cloud_controller_internal").p("cc.max_an
 cpu_weight_min_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_min_memory") %>
 cpu_weight_max_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_max_memory") %>
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>
+
+app_log_revision: <%= link("cloud_controller_internal").p("cc.app_log_revision") %>

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -358,3 +358,5 @@ max_annotations_per_resource: <%= link("cloud_controller_internal").p("cc.max_an
 cpu_weight_min_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_min_memory") %>
 cpu_weight_max_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_max_memory") %>
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>
+
+app_log_revision: <%= link("cloud_controller_internal").p("cc.app_log_revision") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -225,6 +225,7 @@ provides:
   - uaa.clients.cc_routing.secret
   - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
+  - cc.app_log_revision
 
 consumes:
 - name: database
@@ -800,6 +801,9 @@ properties:
   cc.default_app_ssh_access:
     default: true
     description: "When ssh is allowed and not explicitly set in the application, new applications will start with ssh service enabled"
+  cc.app_log_revision:
+    default: false
+    description: "Add revision version to an app's log source. Only applies if an App is using revisions. For example, app logs will be prefixed with APP/REV/1/PROC/WEB/0"
   cc.client_max_body_size:
     default: "15M"
     description: "Maximum body size for nginx"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -431,6 +431,8 @@ cc_service_key_client_secret: <%= p("uaa.clients.cc_service_key_client.secret") 
 allow_app_ssh_access: <%= p("cc.allow_app_ssh_access") %>
 default_app_ssh_access: <%= p("cc.default_app_ssh_access") %>
 
+app_log_revision: <%= p("cc.app_log_revision") %>
+
 skip_cert_verify: <%= p("ssl.skip_cert_verify") %>
 
 install_buildpacks: <%= p("cc.install_buildpacks").to_json %>

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -349,3 +349,5 @@ custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custo
 cpu_weight_min_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_min_memory") %>
 cpu_weight_max_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_max_memory") %>
 max_manifest_service_binding_poll_duration_in_seconds: <%= p("cc.max_manifest_service_binding_poll_duration_in_seconds") %>
+
+app_log_revision: <%= link("cloud_controller_internal").p("cc.app_log_revision") %>

--- a/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
+++ b/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
@@ -78,7 +78,8 @@ module Bosh
               'disable_private_domain_cross_space_context_path_route_sharing' => false,
               'cpu_weight_min_memory' => 128,
               'cpu_weight_max_memory' => 8192,
-              'custom_metric_tag_prefix_list' => ['heck.yes.example.com']
+              'custom_metric_tag_prefix_list' => ['heck.yes.example.com'],
+              'app_log_revision' => true
             }
           }
         end

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -79,7 +79,8 @@ module Bosh
               'custom_metric_tag_prefix_list' => ['heck.yes.example.com'],
               'jobs' => {
                 'enable_dynamic_job_priorities' => false
-              }
+              },
+              'app_log_revision' => true
             }
           }
         end


### PR DESCRIPTION
This new property enables app logs in the format APP/REV/<version>/PROC/WEB/<process>.

We added this property to the following jobs:
* cloud_controller_ng
* cc_deployment_updater
* cloud_controller_clock
* cloud_controller_worker

We believe cloud_controller_worker does not send desired_lrp actions to diego, however we were not completely sure so we added it just incase.

This will be used for Canary Deployments to identify which logs come from with revision of the app

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
