### PR TITLE
 Add threads parameter for delayed workers

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -378,6 +378,8 @@ properties:
     description: "When enabled, the priority of asynchronous jobs will be increased by 1 for each active asynchronous job for that user. 
                   This prevents that a single user, who creates many asynchronous jobs, slows down job execution for other users."
     default: false
+  cc.jobs.number_of_worker_threads:
+    description: "If set multiple delayed job workers will be started as threads in the same process. If not set there will be one delayed job worker per process."
 
   cc.temporary_disable_deployments:
     description: "Do not allow the API client to create app deployments (temporary)"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -94,6 +94,10 @@ jobs:
   <% if_p("cc.jobs.priorities") do |priorities| %>
   priorities: <%= priorities.to_json %>
   <% end %>
+  <% if_p("cc.jobs.number_of_worker_threads") do |number_of_worker_threads| %>
+  number_of_worker_threads: <%= number_of_worker_threads %>
+  <% end %>
+
 
 cpu_weight_min_memory: <%= p("cc.cpu_weight_min_memory") %>
 cpu_weight_max_memory: <%= p("cc.cpu_weight_max_memory") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -123,6 +123,8 @@ properties:
     description: "Maximum health check timeout (in seconds) that can be set for the app"
   cc.jobs.priorities:
     description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
+  cc.jobs.number_of_worker_threads:
+    description: "If set multiple delayed job workers will be started as threads in the same process. If not set there will be one delayed job worker per process."
 
   cc.staging_upload_user:
     description: "User name used to access internal endpoints of Cloud Controller to upload files when staging"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -54,6 +54,9 @@ jobs:
   <% if_p("cc.jobs.priorities") do |priorities| %>
   priorities: <%= priorities.to_json %>
   <% end %>
+  <% if_p("cc.jobs.number_of_worker_threads") do |number_of_worker_threads| %>
+  number_of_worker_threads: <%= number_of_worker_threads %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -710,6 +710,17 @@ module Bosh
               end
             end
           end
+
+          describe 'cc_jobs_number_of_worker_threads' do
+            context "when 'cc.jobs.number_of_worker_threads' is set" do
+              before { merged_manifest_properties['cc']['jobs'] = { 'number_of_worker_threads' => 7 } }
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['jobs']['number_of_worker_threads']).to eq(7)
+              end
+            end
+          end
         end
       end
     end

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -249,6 +249,17 @@ module Bosh
             end
           end
         end
+
+        describe 'cc_jobs_number_of_worker_threads' do
+          context "when 'cc.jobs.number_of_worker_threads' is set" do
+            before { manifest_properties['cc']['jobs'] = { 'number_of_worker_threads' => 7 } }
+
+            it 'renders the correct value into the ccng config' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['jobs']['number_of_worker_threads']).to eq(7)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* A short explanation of the proposed change:
  [cloud_controller_ng/pull/3887](https://github.com/cloudfoundry/cloud_controller_ng/pull/3887) introduces the option run multiple delayed worker threads for one worker process. To allow operators to configure the number of threads a new config parameter is needed.

* Links to any other associated PRs
   - Related to [cloud_controller_ng/pull/3887](https://github.com/cloudfoundry/cloud_controller_ng/pull/3887)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
