### PR TITLE
Run stack_check after DB migrations and seeds

### DIFF
--- a/jobs/cloud_controller_ng/templates/pre-start.sh.erb
+++ b/jobs/cloud_controller_ng/templates/pre-start.sh.erb
@@ -142,7 +142,6 @@ function main {
   start_bosh_dns_or_consul
   setup_directories
   <% if spec.bootstrap && p('cc.run_prestart_migrations') %>
-  stack_check
   perform_migration
   seed_db
     <% if p('cc.database_encryption.skip_validation') %>
@@ -150,6 +149,7 @@ function main {
     <% else %>
     validate_encryption_keys
     <% end %>
+  stack_check
   <% else %>
   echo "Skipping DB migrations and seeds"
   <% end %>


### PR DESCRIPTION
Running the `stack_check` before the initial DB setup fails, as it waits for the database schema to be current (`Sequel::Migrator.is_current?`).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
