### PR TITLE
Revert "Run stack_check after DB migrations and seeds (#453)"

### DIFF
--- a/jobs/cloud_controller_ng/templates/pre-start.sh.erb
+++ b/jobs/cloud_controller_ng/templates/pre-start.sh.erb
@@ -142,6 +142,7 @@ function main {
   start_bosh_dns_or_consul
   setup_directories
   <% if spec.bootstrap && p('cc.run_prestart_migrations') %>
+  stack_check
   perform_migration
   seed_db
     <% if p('cc.database_encryption.skip_validation') %>
@@ -149,7 +150,6 @@ function main {
     <% else %>
     validate_encryption_keys
     <% end %>
-  stack_check
   <% else %>
   echo "Skipping DB migrations and seeds"
   <% end %>


### PR DESCRIPTION
This reverts commit f445c39c88fd3b0f5efed7d873bd2c0198a0a299.

We can now run the stack checker before migrations as per https://github.com/cloudfoundry/cloud_controller_ng/pull/3925.

This is an improvement as we want to fail the stack checker before any migrations have run so that we are not in a state where migrations have run but the deployment has failed

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
