### PR TITLE
Update pcre 8.45 to newer pcre2 10.44

### DIFF
--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -1,7 +1,7 @@
 set -e -x
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre-8.45.tar.gz
+tar xzvf nginx/pcre2-10.44.tar.gz
 
 echo "Extracting nginx_upload module..."
 tar xzvf nginx/nginx-upload-module-2.3.0.tar.gz
@@ -24,7 +24,7 @@ echo "Building nginx..."
 pushd nginx-1.25.2
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
-    --with-pcre=../pcre-8.45 \
+    --with-pcre=../pcre2-10.44 \
     --add-module=../nginx-upload-module-2.3.0 \
     --with-http_stub_status_module \
     --with-http_ssl_module

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -2,7 +2,7 @@
 name: nginx
 files:
 - nginx/nginx-1.25.2.tar.gz
-- nginx/pcre-8.45.tar.gz
+- nginx/pcre2-10.44.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch
 - nginx/upload_module_new_nginx_support.patch

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -12,7 +12,7 @@ pushd expat-2.5.0
 popd
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre-8.45.tar.gz
+tar xzvf nginx/pcre2-10.44.tar.gz
 
 echo "Extracting nginx..."
 tar xzvf nginx/nginx-1.25.2.tar.gz
@@ -31,7 +31,7 @@ pushd nginx-1.25.2
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \
     --with-cc-opt="-I /usr/local/include" \
-    --with-pcre=../pcre-8.45 \
+    --with-pcre=../pcre2-10.44 \
     --with-http_dav_module \
     --with-http_secure_link_module \
     --with-http_ssl_module \

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -3,5 +3,5 @@ name: nginx_webdav
 files:
   - expat/expat-2.5.0.tar.bz2
   - nginx/nginx-1.25.2.tar.gz
-  - nginx/pcre-8.45.tar.gz
+  - nginx/pcre2-10.44.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz


### PR DESCRIPTION
PCRE (Perl Compatible Regular Expressions) is part of the nginx packaging scripts.
We use an outdated version 8.45. The current version of pcre2 is 10.44.
Updating to newer version pcre2 10.44.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
