### PR TITLE
Revert "Update pcre 8.45 to newer pcre2 10.44 (#455)"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -86,10 +86,10 @@ nginx/nginx-upload-module-2.3.0.tar.gz:
   size: 40139
   object_id: 2f8f59a7-8e90-4bf5-67d8-1637924ab331
   sha: sha256:c86e318addb9c88d70fdbd58ff1f6ef6f404a93070f6db8017a1f880c97946c4
-nginx/pcre2-10.44.tar.gz:
-  size: 2552792
-  object_id: ef1fbb4d-8503-4270-67f3-1ad748b8b5fe
-  sha: sha256:86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
+nginx/pcre-8.45.tar.gz:
+  size: 2096552
+  object_id: a90f9f20-e23b-4755-59c7-101197325dab
+  sha: sha256:4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09
 postgres/postgresql-11.22.tar.gz:
   size: 26826810
   object_id: d1f8d34c-b438-44e7-7672-5daea8a6da66

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -1,7 +1,7 @@
 set -e -x
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre2-10.44.tar.gz
+tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx_upload module..."
 tar xzvf nginx/nginx-upload-module-2.3.0.tar.gz
@@ -24,7 +24,7 @@ echo "Building nginx..."
 pushd nginx-1.25.2
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
-    --with-pcre=../pcre2-10.44 \
+    --with-pcre=../pcre-8.45 \
     --add-module=../nginx-upload-module-2.3.0 \
     --with-http_stub_status_module \
     --with-http_ssl_module

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -2,7 +2,7 @@
 name: nginx
 files:
 - nginx/nginx-1.25.2.tar.gz
-- nginx/pcre2-10.44.tar.gz
+- nginx/pcre-8.45.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch
 - nginx/upload_module_new_nginx_support.patch

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -12,7 +12,7 @@ pushd expat-2.5.0
 popd
 
 echo "Extracting pcre..."
-tar xzvf nginx/pcre2-10.44.tar.gz
+tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx..."
 tar xzvf nginx/nginx-1.25.2.tar.gz
@@ -31,7 +31,7 @@ pushd nginx-1.25.2
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \
     --with-cc-opt="-I /usr/local/include" \
-    --with-pcre=../pcre2-10.44 \
+    --with-pcre=../pcre-8.45 \
     --with-http_dav_module \
     --with-http_secure_link_module \
     --with-http_ssl_module \

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -3,5 +3,5 @@ name: nginx_webdav
 files:
   - expat/expat-2.5.0.tar.bz2
   - nginx/nginx-1.25.2.tar.gz
-  - nginx/pcre2-10.44.tar.gz
+  - nginx/pcre-8.45.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz


### PR DESCRIPTION
This reverts commit ecc2b5d & ecc2b5d9dcb6c270fecb8e446d3acdd18e8580ef
pcre2 causes the following error when executing CATS:
```
Unknown field(s): '<ngx_upload_module_dummy>', Upload must include either resources or bits, File field missing path information
```



* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
