### PR TITLE
Turn on audit logging in worker/clock by default

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -151,7 +151,7 @@ properties:
     default: "debug2"
     description: "Level at which cc database operations will be logged if cc.log_db_queries is set to true."
   cc.log_audit_events:
-    default: false
+    default: true
     description: "Log audit events"
 
   cc.staging_timeout_in_seconds:

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -109,7 +109,7 @@ properties:
     default: false
     description: "Log fog requests and responses."
   cc.log_audit_events:
-    default: false
+    default: true
     description: "Log audit events"
 
   cc.staging_timeout_in_seconds:


### PR DESCRIPTION
A simple solution for #458, however we should probably just remove the configuration of this property completely from the worker/clock specs.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
