### PR TITLE
Add percent monit memory thresholds

### DIFF
--- a/jobs/cc_deployment_updater/monit
+++ b/jobs/cc_deployment_updater/monit
@@ -4,7 +4,16 @@ check process cc_deployment_updater
   start program "/var/vcap/jobs/bpm/bin/bpm start cc_deployment_updater"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cc_deployment_updater"
   group vcap
+  <% if_p("cc.thresholds.api.alert_if_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_memory_percent") %> % for 3 cycles then alert
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  <% end %>
+
+  <% if_p("cc.thresholds.api.restart_if_consistently_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_memory_percent") %> % for 15 cycles then restart
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then restart
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then restart
+  <% end %>
 <% end %>

--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -129,6 +129,10 @@ properties:
   cc.thresholds.api.restart_if_above_mb:
     description: "The CC will restart if memory remains above this threshold for 3 monit cycles"
     default: 3750
+  cc.thresholds.api.alert_if_above_memory_percent:
+    description: "The cc will alert if memory remains above this percent threshold for 3 monit cycles. If specified, this threshold is used over `cc.thresholds.api.alert_if_above_mb`. Value must be percent integer, e.g. '80'."
+  cc.thresholds.api.restart_if_consistently_above_memory_percent:
+    description: "The cc will restart if memory remains above this percent threshold for 15 monit cycles. If specified, this threshold is used over `cc.thresholds.api.restart_if_consistently_above_mb` and `restart_if_above_mb`. Value must be percent integer, e.g. '80'."
 
   cc.diego.bbs.url:
     description: "URL of the BBS Server"

--- a/jobs/cloud_controller_clock/monit
+++ b/jobs/cloud_controller_clock/monit
@@ -3,6 +3,15 @@ check process cloud_controller_clock
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_clock"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_clock"
   group vcap
+  <% if_p("cc.thresholds.api.alert_if_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_memory_percent") %> % for 3 cycles then alert
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  <% end %>
+
+  <% if_p("cc.thresholds.api.restart_if_consistently_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_memory_percent") %> % for 15 cycles then restart
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then restart
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then restart
+  <% end %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -471,6 +471,10 @@ properties:
   cc.thresholds.api.restart_if_above_mb:
     description: "The cc will restart if memory remains above this threshold for 3 monit cycles"
     default: 3750
+  cc.thresholds.api.alert_if_above_memory_percent:
+    description: "The cc will alert if memory remains above this percent threshold for 3 monit cycles. If specified, this threshold is used over `cc.thresholds.api.alert_if_above_mb`. Value must be percent integer, e.g. '80'."
+  cc.thresholds.api.restart_if_consistently_above_memory_percent:
+    description: "The cc will restart if memory remains above this percent threshold for 15 monit cycles. If specified, this threshold is used over `cc.thresholds.api.restart_if_consistently_above_mb` and `restart_if_above_mb`. Value must be percent integer, e.g. '80'."
 
   cc.diego.bbs.url:
     description: "URL of the BBS Server"

--- a/jobs/cloud_controller_ng/monit
+++ b/jobs/cloud_controller_ng/monit
@@ -3,9 +3,19 @@ check process cloud_controller_ng
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng"
   group vcap
+
+  <% if_p("cc.thresholds.api.alert_if_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_memory_percent") %> % for 3 cycles then alert
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  <% end %>
+
+  <% if_p("cc.thresholds.api.restart_if_consistently_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_memory_percent") %> % for <%= p("cc.thresholds.api.restart_if_consistently_above_mb_cycles") %> cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for <%= p("cc.thresholds.api.restart_if_consistently_above_mb_cycles") %> cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
+  <% end %>
 
 check process ccng_monit_http_healthcheck
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/ccng_monit_http_healthcheck.pid
@@ -21,9 +31,19 @@ check process cloud_controller_worker_local_<%= index %>
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p local_worker_<%= index %>"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p local_worker_<%= index %>"
   group vcap
+  <% if_p("cc.thresholds.api.alert_if_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.alert_if_above_memory_percent") %> % for 3 cycles then alert
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
+  <% end %>
+
+  <% if_p("cc.thresholds.api.restart_if_consistently_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_memory_percent") %> % 15 cycles then restart
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then restart
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then restart
+  <% end %>
+
 <% end %>
 
 check process nginx_cc

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -946,7 +946,7 @@ properties:
     description: "The cc will restart if memory remains above this threshold for n monit cycles"
     default: 3500
   cc.thresholds.api.restart_if_consistently_above_mb_cycles:
-    description: "Monit cycles for 'restart_if_consistently_above_mb'. Default is 15 cycles"
+    description: "Monit cycles for 'restart_if_consistently_above_mb' and `restart_if_consistently_above_memory_percent`. Default is 15 cycles"
     default: 15
   cc.thresholds.api.restart_if_above_mb:
     description: "The cc will restart if memory remains above this threshold for 3 monit cycles"
@@ -954,6 +954,10 @@ properties:
   cc.thresholds.api.restart_if_monit_connection_test_consistently_fails_cycles:
     description: "Number of monit cycles until a failing unixsocket test triggers a restart. Default is 60 cycles (i.e. 10 minutes)"
     default: 60
+  cc.thresholds.api.alert_if_above_memory_percent:
+    description: "The cc will alert if memory remains above this percent threshold for 3 monit cycles. If specified, this threshold is used over `cc.thresholds.api.alert_if_above_mb`. Value must be percent integer, e.g. '80'."
+  cc.thresholds.api.restart_if_consistently_above_memory_percent:
+    description: "The cc will restart if memory remains above this percent threshold for n monit cycles. If specified, this threshold is used over `cc.thresholds.api.restart_if_consistently_above_mb` and `restart_if_above_mb`. Value must be percent integer, e.g. '80'."
 
   dea_next.staging_memory_limit_mb:
     description: "Memory limit in MB for staging tasks"

--- a/jobs/cloud_controller_worker/monit
+++ b/jobs/cloud_controller_worker/monit
@@ -4,7 +4,16 @@ check process cloud_controller_worker_<%= index %>
   start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_worker -p worker_<%= index %>"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_worker -p worker_<%= index %>"
   group vcap
+  <% if_p("cc.thresholds.worker.alert_if_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.worker.alert_if_above_memory_percent") %> % for 3 cycles then alert
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.worker.alert_if_above_mb") %> Mb for 3 cycles then alert
+  <% end %>
+
+  <% if_p("cc.thresholds.worker.restart_if_consistently_above_memory_percent") do %>
+  if totalmem > <%= p("cc.thresholds.worker.restart_if_consistently_above_memory_percent") %> % for 15 cycles then restart
+  <% end.else do %>
   if totalmem > <%= p("cc.thresholds.worker.restart_if_consistently_above_mb") %> Mb for 15 cycles then restart
   if totalmem > <%= p("cc.thresholds.worker.restart_if_above_mb") %> Mb for 3 cycles then restart
+  <% end %>
 <% end %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -446,6 +446,10 @@ properties:
   cc.thresholds.worker.restart_if_above_mb:
     description: "The CC will restart if memory remains above this threshold for 3 monit cycles"
     default: 512
+  cc.thresholds.worker.alert_if_above_memory_percent:
+    description: "The CC will alert if memory remains above this percent threshold for 3 monit cycles. If specified, this threshold is used over `cc.thresholds.worker.alert_if_above_mb`. Value must be percent integer, e.g. '80'."
+  cc.thresholds.worker.restart_if_consistently_above_memory_percent:
+    description: "The CC will restart if memory remains above this percent threshold for 15 monit cycles. If specified, this threshold is used over `cc.thresholds.worker.restart_if_consistently_above_mb` and `restart_if_above_mb`. Value must be percent integer, e.g. '80'."
 
   cc.disable_custom_buildpacks:
     default: false


### PR DESCRIPTION
Add a new optional method to specify memory thresholds.This percent method allows for easier use of Puma where the VM size maybe scaled verticially, this method allows these thresholds to also scale.

Thin could only be scaled horizontally, Puma can be scaled vertically. Due to this the default memory in MB values may be insufficient for Puma installations on large VMs where there is more resource utilisation. Therefore instead of having to configure the MB threshold for the Puma installation based on the VM size, we add a percentage method that can be configured this allows the threshold to scales with the VM.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
