### PR TITLE
WIP: Do not use readiness port on worker by default

### DIFF
--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -78,7 +78,7 @@ properties:
 
   cc.readiness_port.cloud_controller_worker:
     description: "Readiness port used in k8s to check that db migrations are complete before component update"
-    default: 9025
+    default: -1
 
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overriden per job"

--- a/jobs/cloud_controller_worker/templates/post-start.sh.erb
+++ b/jobs/cloud_controller_worker/templates/post-start.sh.erb
@@ -13,7 +13,11 @@ function fix_bundler_home_permissions {
 
 fix_bundler_home_permissions
 
+<% if_p("cc.readiness_port.cloud_controller_worker") do |prop| %>
+<% if prop > 0 %>
 while ! nc -z localhost <%= p("cc.readiness_port.cloud_controller_worker") %>
 do
   sleep 1
 done
+<% end %>
+<% end %>


### PR DESCRIPTION
TODO: work in progress

Fixes #256

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
