### PR TITLE
Add timeout parameter for generic queue

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -368,6 +368,8 @@ properties:
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overridden per job"
     default: 14400 # 4 hours
+  cc.jobs.queues.cc_generic.timeout_in_seconds:
+    description: "The longest jobs in the cc-generic queue can take before they are cancelled"
   cc.jobs.blobstore_delete.timeout_in_seconds:
     description: "The longest this job can take before it is cancelled"
   cc.jobs.droplet_upload.timeout_in_seconds:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -83,6 +83,11 @@ jobs:
   enable_dynamic_job_priorities: <%= p("cc.jobs.enable_dynamic_job_priorities") %>
   global:
     timeout_in_seconds: <%= p("cc.jobs.global.timeout_in_seconds") %>
+  queues:
+    <% if_p("cc.jobs.queues.cc_generic.timeout_in_seconds") do |timeout| %>
+    cc_generic:
+      timeout_in_seconds: <%= timeout %>
+    <% end %>
   <% if_p("cc.jobs.blobstore_delete.timeout_in_seconds") do |timeout| %>
   blobstore_delete:
     timeout_in_seconds: <%= timeout %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -721,6 +721,24 @@ module Bosh
               end
             end
           end
+
+          describe 'cc_jobs_queues' do
+            context 'when cc.jobs.queues is not set' do
+              it 'does not render ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['jobs']['queues']).to be_nil
+              end
+            end
+
+            context  "when 'cc.jobs.queues.cc_generic.timeout_in_seconds' is set" do
+              before { merged_manifest_properties['cc']['jobs'] = { 'queues' => { 'cc_generic' => { 'timeout_in_seconds' => 10 } } } }
+
+              it 'renders the correct value into the ccng config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['jobs']['queues']['cc_generic']['timeout_in_seconds']).to eq(10)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Introduces `cc.jobs.queues.cc_generic.timeout_in_seconds` parameter which allows operators to configure a dedicated timeout for jobs in the cc-generic queue. 
Generic jobs are only enqueued on API VMs, thus the parameter is not needed for workers, clock etc.


* Links to any other associated PRs
  Related to [ccng PR #3945](https://github.com/cloudfoundry/cloud_controller_ng/pull/3945).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
