### PR TITLE
Ensure gems don't have world-writable files

### DIFF
--- a/packages/cloud_controller_ng/packaging
+++ b/packages/cloud_controller_ng/packaging
@@ -12,3 +12,6 @@ export PATH=$libpq_dir/bin:$PATH
 bundle config build.pg --with-pg-lib=$libpq_dir/lib --with-pg-include=$libpq_dir/include
 bundle config build.mysql2 --with-mysql-config=$mariadb_dir/bin/mariadb_config-wrapper.sh
 bosh_bundle_local --deployment
+
+# remove world-writable permissions on files if a gem has them
+chmod -R o-w ../gem_home


### PR DESCRIPTION
One gem we install has a few world-writable files.

Thankfully, none of them are actually loaded while running CC, as far as I can tell, but this was flagged by a scanner as a potential security issue. 

See this issue for more info: https://github.com/rdp/os/issues/44.  It appears to have been unintentional, so if this can happen accidentally we'd like to prevent it in the future.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
