### PR TITLE
Ensure queues parameter is set to empty hash

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -84,9 +84,11 @@ jobs:
   global:
     timeout_in_seconds: <%= p("cc.jobs.global.timeout_in_seconds") %>
   queues:
-    <% if_p("cc.jobs.queues.cc_generic.timeout_in_seconds") do |timeout| %>
+    <% if (timeout = p("cc.jobs.queues.cc_generic.timeout_in_seconds", nil)) %>
     cc_generic:
       timeout_in_seconds: <%= timeout %>
+    <% else %>
+    {}
     <% end %>
   <% if_p("cc.jobs.blobstore_delete.timeout_in_seconds") do |timeout| %>
   blobstore_delete:

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -47,6 +47,7 @@ jobs:
   enable_dynamic_job_priorities: <%= link("cloud_controller_internal").p("cc.jobs.enable_dynamic_job_priorities") %>
   global:
     timeout_in_seconds: <%= p("cc.jobs.global.timeout_in_seconds") %>
+  queues: {}
   <% if_p("cc.jobs.blobstore_delete.timeout_in_seconds") do |timeout| %>
   blobstore_delete:
     timeout_in_seconds: <%= timeout %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -726,7 +726,7 @@ module Bosh
             context 'when cc.jobs.queues is not set' do
               it 'does not render ccng config' do
                 template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
-                expect(template_hash['jobs']['queues']).to be_nil
+                expect(template_hash['jobs']['queues']).to eq({})
               end
             end
 

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -260,6 +260,15 @@ module Bosh
             end
           end
         end
+
+        describe 'cc_jobs_queues' do
+          context 'when cc.jobs.queues is not set' do
+            it 'does not render ccng config' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['jobs']['queues']).to eq({})
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Ensure queues parameter is set to empty hash otherwise the schema validation might fail with nil errors.


* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
