### PR TITLE
Configurable pollable jobs cleanup

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -110,6 +110,9 @@ properties:
   cc.completed_tasks.cutoff_age_in_days:
     description: "The age at which completed tasks are pruned from the Cloud Controller database"
     default: 31
+  cc.pollable_jobs.cutoff_age_in_days:
+    description: "How old a pollable job should stay in cloud controller database before being cleaned up"
+    default: 90
 
   cc.failed_jobs.max_number_of_failed_delayed_jobs:
     description: "Maximum number of failed jobs that should stay in cloud controller database before being cleaned up"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -90,6 +90,9 @@ failed_jobs:
   <% end %>
   frequency_in_seconds: <%= p("cc.failed_jobs.frequency_in_seconds") %>
 
+pollable_jobs:
+  cutoff_age_in_days: <%= p("cc.pollable_jobs.cutoff_age_in_days") %>
+
 service_operations_initial_cleanup:
   frequency_in_seconds: <%= p("cc.service_operations_initial_cleanup.frequency_in_seconds") %>
 


### PR DESCRIPTION
Related cloud_controller_ng PR: cloudfoundry/cloud_controller_ng#3980

The default value (i.e. 90 days) equals the previously hard-coded interval.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
