### PR TITLE
Update nginx to latest version 1.27.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -78,6 +78,10 @@ nginx/nginx-1.25.2.tar.gz:
   size: 1214903
   object_id: 09cbde3f-4123-4091-778e-555347700100
   sha: sha256:05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711
+nginx/nginx-1.27.1.tar.gz:
+  size: 1245244
+  object_id: e7028095-e709-4222-7c3b-2eb810ec577b
+  sha: sha256:bd7ba68a6ce1ea3768b771c7e2ab4955a59fb1b1ae8d554fedb6c2304104bdfc
 nginx/nginx-dav-ext-module-3.0.0.tar.gz:
   size: 14558
   object_id: 44648d53-c24b-45e4-4434-007713aa5fe7

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -74,10 +74,6 @@ nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   size: 5222
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d
   sha: sha256:a5a7f9b3a7e20302943b1dd448d9b725cf3cb28d774d79f618aab7c4ddeea52b
-nginx/nginx-1.25.2.tar.gz:
-  size: 1214903
-  object_id: 09cbde3f-4123-4091-778e-555347700100
-  sha: sha256:05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711
 nginx/nginx-1.27.1.tar.gz:
   size: 1245244
   object_id: e7028095-e709-4222-7c3b-2eb810ec577b

--- a/packages/nginx/README.md
+++ b/packages/nginx/README.md
@@ -4,8 +4,8 @@ This repo is used for nginx and nginx-webdav packaging in BOSH deployments.
 
 The files can be downloaded from the following locations:
 
-| Filename                         | Download URL                                                                                                     |
-|----------------------------------|------------------------------------------------------------------------------------------------------------------|
-| nginx-1.25.2.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.25.2.tar.gz)                                                       |
+| Filename                         | Download URL                                                                                                      |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| nginx-1.27.1.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.27.1.tar.gz)                                                        |
 | nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz) 
-| pcre-8.45.tar.gz | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz)                               |
+| pcre-8.45.tar.gz                 | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz)                                |

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -13,15 +13,15 @@ pushd nginx-upload-module-2.3.0
 popd
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.25.2.tar.gz
+tar xzvf nginx/nginx-1.27.1.tar.gz
 
-sed -i 's@"nginx/"@"-/"@g' nginx-1.25.2/src/core/nginx.h
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/ngx_http_header_filter_module.c
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/v2/ngx_http_v2_filter_module.c
-sed -i 's@<hr><center>nginx</center>@@g' nginx-1.25.2/src/http/ngx_http_special_response.c
+sed -i 's@"nginx/"@"-/"@g' nginx-1.27.1/src/core/nginx.h
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/ngx_http_header_filter_module.c
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
+sed -i 's@<hr><center>nginx</center>@@g' nginx-1.27.1/src/http/ngx_http_special_response.c
 
 echo "Building nginx..."
-pushd nginx-1.25.2
+pushd nginx-1.27.1
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.45 \

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -1,7 +1,7 @@
 ---
 name: nginx
 files:
-- nginx/nginx-1.25.2.tar.gz
+- nginx/nginx-1.27.1.tar.gz
 - nginx/pcre-8.45.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch

--- a/packages/nginx_webdav/packaging
+++ b/packages/nginx_webdav/packaging
@@ -15,18 +15,18 @@ echo "Extracting pcre..."
 tar xzvf nginx/pcre-8.45.tar.gz
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.25.2.tar.gz
+tar xzvf nginx/nginx-1.27.1.tar.gz
 
 echo "Extracting webdav extensions"
 tar xzvf nginx/nginx-dav-ext-module-3.0.0.tar.gz
 
-sed -i 's@"nginx/"@"-/"@g' nginx-1.25.2/src/core/nginx.h
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/ngx_http_header_filter_module.c
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.25.2/src/http/v2/ngx_http_v2_filter_module.c
-sed -i 's@<hr><center>nginx</center>@@g' nginx-1.25.2/src/http/ngx_http_special_response.c
+sed -i 's@"nginx/"@"-/"@g' nginx-1.27.1/src/core/nginx.h
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/ngx_http_header_filter_module.c
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
+sed -i 's@<hr><center>nginx</center>@@g' nginx-1.27.1/src/http/ngx_http_special_response.c
 
 echo "Building nginx..."
-pushd nginx-1.25.2
+pushd nginx-1.27.1
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-ld-opt="-L /usr/local/lib" \

--- a/packages/nginx_webdav/spec
+++ b/packages/nginx_webdav/spec
@@ -2,6 +2,6 @@
 name: nginx_webdav
 files:
   - expat/expat-2.5.0.tar.bz2
-  - nginx/nginx-1.25.2.tar.gz
+  - nginx/nginx-1.27.1.tar.gz
   - nginx/pcre-8.45.tar.gz
   - nginx/nginx-dav-ext-module-3.0.0.tar.gz


### PR DESCRIPTION
* A short explanation of the proposed change:
Update nginx from 1.25.2 to latest version 1.27.1.

* An explanation of the use cases your change solves
Latest version comes with several bug fixes. Current version 1.25.2 is over a year old.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite -> ran CATs on AWS bbl env with cf-deployment v43.3.0
