### PR TITLE
Revert "Bump nginx to 1.27.2"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -74,10 +74,10 @@ nginx/newrelic_nginx_agent-1.2.1.tar.gz:
   size: 5222
   object_id: c63358f6-574a-4e20-9d2b-7e1450368b6d
   sha: sha256:a5a7f9b3a7e20302943b1dd448d9b725cf3cb28d774d79f618aab7c4ddeea52b
-nginx/nginx-1.27.2.tar.gz:
-  size: 1258098
-  object_id: c13322ee-f9bd-4e8d-617f-747dbafb797b
-  sha: sha256:a91ecfc3a0b3a2c1413afca627bd886d76e0414b81cad0fb7872a9655a1b25fa
+nginx/nginx-1.27.1.tar.gz:
+  size: 1245244
+  object_id: e7028095-e709-4222-7c3b-2eb810ec577b
+  sha: sha256:bd7ba68a6ce1ea3768b771c7e2ab4955a59fb1b1ae8d554fedb6c2304104bdfc
 nginx/nginx-dav-ext-module-3.0.0.tar.gz:
   size: 14558
   object_id: 44648d53-c24b-45e4-4434-007713aa5fe7

--- a/packages/nginx/README.md
+++ b/packages/nginx/README.md
@@ -6,6 +6,6 @@ The files can be downloaded from the following locations:
 
 | Filename                         | Download URL                                                                                                      |
 |----------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| nginx-1.27.2.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.27.2.tar.gz)                                                        |
+| nginx-1.27.1.tar.gz              | [nginx.org](http://nginx.org/download/nginx-1.27.1.tar.gz)                                                        |
 | nginx-upload-module-2.3.0.tar.gz | [github.com/vkholodkov/nginx-upload-module](https://github.com/fdintino/nginx-upload-module/archive/2.3.0.tar.gz) 
 | pcre-8.45.tar.gz                 | [pcre.org](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.45.tar.gz)                                |

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -13,15 +13,15 @@ pushd nginx-upload-module-2.3.0
 popd
 
 echo "Extracting nginx..."
-tar xzvf nginx/nginx-1.27.2.tar.gz
+tar xzvf nginx/nginx-1.27.1.tar.gz
 
-sed -i 's@"nginx/"@"-/"@g' nginx-1.27.2/src/core/nginx.h
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.2/src/http/ngx_http_header_filter_module.c
-sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.2/src/http/v2/ngx_http_v2_filter_module.c
-sed -i 's@<hr><center>nginx</center>@@g' nginx-1.27.2/src/http/ngx_http_special_response.c
+sed -i 's@"nginx/"@"-/"@g' nginx-1.27.1/src/core/nginx.h
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/ngx_http_header_filter_module.c
+sed -i 's@r->headers_out.server == NULL@0@g' nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
+sed -i 's@<hr><center>nginx</center>@@g' nginx-1.27.1/src/http/ngx_http_special_response.c
 
 echo "Building nginx..."
-pushd nginx-1.27.2
+pushd nginx-1.27.1
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET} \
     --with-pcre=../pcre-8.45 \

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -1,7 +1,7 @@
 ---
 name: nginx
 files:
-- nginx/nginx-1.27.2.tar.gz
+- nginx/nginx-1.27.1.tar.gz
 - nginx/pcre-8.45.tar.gz
 - nginx/nginx-upload-module-2.3.0.tar.gz
 - nginx/upload_module_put_support.patch


### PR DESCRIPTION
This reverts the latest nginx update (commit 6c497f98faddd0adf261728b8eb37f2cf8479bd1). It causes errors like this:
```
Building a release from directory '/tmp/build/cc76e2d9/capi-release':
  - Constructing packages from directory:
      - Reading package from '/tmp/build/cc76e2d9/capi-release/packages/nginx_webdav':
          Collecting package files:
            Missing files for pattern 'nginx/nginx-1.27.1.tar.gz'
  - Constructing jobs from manifest:
      - Expected to find package 'nginx_webdav' since it's a dependency of job 'blobstore'
      - Expected to find package 'capi_utils' since it's a dependency of job 'cc_deployment_updater'
      - Expected to find package 'capi_utils' since it's a dependency of job 'cc_uploader'
      - Expected to find package 'capi_utils' since it's a dependency of job 'cloud_controller_clock'
      - Expected to find package 'capi_utils' since it's a dependency of job 'cloud_controller_ng'
      - Expected to find package 'capi_utils' since it's a dependency of job 'cloud_controller_worker'
      - Expected to find package 'nfs-debs' since it's a dependency of job 'nfs_mounter'
      - Expected to find package 'capi_utils' since it's a dependency of job 'rotate_cc_database_key'
      - Expected to find package 'capi_utils' since it's a dependency of job 'tps'
      - Expected to find package 'valkey' since it's a dependency of job 'valkey'
Exit code 1

```
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
