### PR TITLE
Disable /v2/info endpoint if temporary_enable_v2 == false

### DIFF
--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -488,6 +488,8 @@ rate_limiter_v2_api:
   per_process_admin_limit: <%= (p("cc.rate_limiter_v2_api.admin_limit").to_f/instances).ceil %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter_v2_api.reset_interval_in_minutes") %>
 
+temporary_enable_v2: <%= p("cc.temporary_enable_v2") %>
+
 <% if p("cc.experimental.use_puma_webserver") || p("cc.experimental.use_redis") %>
 redis:
   socket: "/var/vcap/data/valkey/valkey.sock"

--- a/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
@@ -34,7 +34,7 @@ location / {
 }
 
 <% if !p("cc.temporary_enable_v2") %>
-location ~ /v2(?!/info) {
+location ~ /v2/ {
   return 404 "V2 endpoints disabled";
 }
 <% end %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -104,7 +104,8 @@ module Bosh
                   [{ 'description' => 'Cloud Foundry Linux-based filesystem',
                      'name' => 'cflinuxfs4' }],
                 'staging_upload_password' => '((cc_staging_upload_password))',
-                'staging_upload_user' => 'staging_user' },
+                'staging_upload_user' => 'staging_user',
+                'temporary_enable_v2' => true },
             'ccdb' =>
               { 'databases' => [{ 'name' => 'cloud_controller', 'tag' => 'cc' }],
                 'db_scheme' => 'mysql',
@@ -497,6 +498,24 @@ module Bosh
               template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links + [self_link]))
               expect(template_hash['rate_limiter_v2_api']['per_process_general_limit']).to eq(334)
               expect(template_hash['rate_limiter_v2_api']['per_process_admin_limit']).to eq(667)
+            end
+          end
+
+          describe 'enable v2 API' do
+            it 'is by default true' do
+              template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+              expect(template_hash['temporary_enable_v2']).to be(true)
+            end
+
+            context 'when explicitly disabled' do
+              before do
+                merged_manifest_properties['cc']['temporary_enable_v2'] = false
+              end
+
+              it 'is false' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['temporary_enable_v2']).to be(false)
+              end
             end
           end
 


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Disable /v2/info endpoint if temporary_enable_v2 == false.

* An explanation of the use cases your change solves
Part of the v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4034

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
