### PR TITLE
Make puma default webserver

### DIFF
--- a/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
+++ b/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
@@ -7,8 +7,6 @@ cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 export RUBYOPT='--yjit'
 <% end %>
 
-<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
-  export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
+export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
 
 exec bundle exec rake deployment_updater:start

--- a/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
+++ b/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
@@ -7,8 +7,6 @@ cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 export RUBYOPT='--yjit'
 <% end %>
 
-<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
 
 exec bundle exec rake clock:start

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1263,14 +1263,15 @@ properties:
 
   cc.puma.workers:
     description: "Number of workers for Puma webserver."
-    default: 3
+    default: 2
 
   cc.puma.max_threads:
     description: "Maximum number of threads per Puma webserver worker."
-    default: 2
+    default: 10
 
   cc.puma.max_db_connections_per_process:
-    description: "Maximum database connections for Puma per process (main + Puma workers), if not set the ccng value is used (default)"
+    description: "Maximum database connections for Puma per process (main + Puma workers)."
+    default: 10
 
   cc.update_metric_tags_on_rename:
     description: "Enable sending a Desired LRP update when an app is renamed"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -224,11 +224,11 @@ provides:
   - ssl.skip_cert_verify
   - system_domain
   - uaa.clients.cc_routing.secret
-  - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
   - cc.app_log_revision
   - cc.app_instance_stopping_state
   - cc.deprecated_stacks
+  - cc.temporary_enable_deprecated_thin_webserver
   
 consumes:
 - name: database
@@ -1257,10 +1257,6 @@ properties:
     description: "Enables jemalloc rather than malloc for Cloud Controller API servers and workers; however, it's experimental and not typically recommended, so review its pros and cons before use."
     default: false
 
-  cc.experimental.use_puma_webserver:
-    description: "Use Puma in place of Thin as the webserver. This may increase performance as Puma forks Cloud Controller processes to avoid relying on threads"
-    default: false
-
   cc.experimental.use_redis:
     description: "Use co-deployed Valkey (Redis fork) for rate limiting and metrics. If the Puma webserver is enabled, Valkey will automatically be used."
     default: false
@@ -1282,4 +1278,8 @@ properties:
 
   cc.legacy_md5_buildpack_paths_enabled:
     description: "Enable legacy MD5 buildpack paths. If disabled, xxhash64 is used for calculating paths in buildpack image layers."
+    default: false
+
+  cc.temporary_enable_deprecated_thin_webserver:
+    description: "Use deprecated Thin webserver. Please note that when using Thin instead of Puma you miss out on the following benefits: Better resource utilization, well maintained, more performant.."
     default: false

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -163,7 +163,6 @@ provides:
   - cc.external_port
   - cc.external_protocol
   - cc.experimental.use_yjit_compiler
-  - cc.experimental.use_jemalloc_memory_allocator
   - cc.internal_service_hostname
   - cc.jobs.enable_dynamic_job_priorities
   - cc.log_db_queries
@@ -1253,10 +1252,6 @@ properties:
     description: "Use Ruby's YJIT compiler when running Cloud Controller API servers and workers. This feature is experimental and not recommended. Please review the drawbacks and benefits of YJIT before enabling."
     default: false
 
-  cc.experimental.use_jemalloc_memory_allocator:
-    description: "Enables jemalloc rather than malloc for Cloud Controller API servers and workers; however, it's experimental and not typically recommended, so review its pros and cons before use."
-    default: false
-
   cc.experimental.use_redis:
     description: "Use co-deployed Valkey (Redis fork) for rate limiting and metrics. If the Puma webserver is enabled, Valkey will automatically be used."
     default: false
@@ -1282,5 +1277,5 @@ properties:
     default: false
 
   cc.temporary_enable_deprecated_thin_webserver:
-    description: "Use deprecated Thin webserver. Please note that when using Thin instead of Puma you miss out on the following benefits: Better resource utilization, well maintained, more performant.."
+    description: "Use deprecated Thin webserver. Please note that when using Thin instead of Puma you miss out on the following benefits: Better resource utilization, well maintained and more performant. Thin will be removed in a future release."
     default: false

--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -18,9 +18,7 @@ echo 'Finished migrations and seeds'
 export RUBYOPT='--yjit'
 <% end %>
 
-<% if p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
 
 exec /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller \
   -c /var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml

--- a/jobs/cloud_controller_ng/templates/bin/local_worker.erb
+++ b/jobs/cloud_controller_ng/templates/bin/local_worker.erb
@@ -9,9 +9,7 @@ wait_for_blobstore
 export RUBYOPT='--yjit'
 <% end %>
 
-<% if p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 exec bundle exec rake "jobs:local[cc_api_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]"

--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -13,7 +13,7 @@ def mount_nfs_volume!(config)
 end
 
 def mount_valkey_volume!(config)
-  if p("cc.experimental.use_puma_webserver") || p("cc.experimental.use_redis")
+  unless p("cc.temporary_enable_deprecated_thin_webserver") && !p("cc.experimental.use_redis")
     config['additional_volumes'] = [] unless config.key?('additional_volumes')
     config['additional_volumes'] << {
       "path" => "/var/vcap/data/valkey",

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -53,7 +53,7 @@ local_route: <%= p('cc.nginx.ip') %>
 external_port: <%= p("cc.external_port") %>
 tls_port: <%= p("cc.tls_port") %>
 internal_service_hostname: <%= p("cc.internal_service_hostname") %>
-webserver: <%= p("cc.experimental.use_puma_webserver") ? 'puma' : 'thin' %>
+webserver: <%= p("cc.temporary_enable_deprecated_thin_webserver") ? 'thin' : 'puma' %>
 puma:
   workers: <%= p("cc.puma.workers") %>
   max_threads: <%= p("cc.puma.max_threads") %>
@@ -488,7 +488,7 @@ rate_limiter_v2_api:
   per_process_admin_limit: <%= (p("cc.rate_limiter_v2_api.admin_limit").to_f/instances).ceil %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter_v2_api.reset_interval_in_minutes") %>
 
-<% if p("cc.experimental.use_puma_webserver") || p("cc.experimental.use_redis") %>
+<% unless p("cc.temporary_enable_deprecated_thin_webserver") && !p("cc.experimental.use_redis") %>
 redis:
   socket: "/var/vcap/data/valkey/valkey.sock"
 <% end %>

--- a/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
+++ b/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
@@ -9,9 +9,7 @@ wait_for_blobstore
 export RUBYOPT='--yjit'
 <% end %>
 
-<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 

--- a/jobs/rotate_cc_database_key/templates/bin/run.erb
+++ b/jobs/rotate_cc_database_key/templates/bin/run.erb
@@ -2,9 +2,7 @@
 
 set -eu
 
-<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
-  export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
-<% end %>
+export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
 
 rotate() {
   export CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/rotate_cc_database_key/config/cloud_controller_ng.yml

--- a/jobs/valkey/monit
+++ b/jobs/valkey/monit
@@ -1,6 +1,6 @@
 <%
   cloud_controller_internal = link("cloud_controller_internal")
-  if cloud_controller_internal.p("cc.experimental.use_puma_webserver") || cloud_controller_internal.p("cc.experimental.use_redis")
+  unless cloud_controller_internal.p("cc.temporary_enable_deprecated_thin_webserver") && !cloud_controller_internal.p("cc.experimental.use_redis")
 %>
 
 check process valkey

--- a/spec/cloud_controller_ng/bpm_spec.rb
+++ b/spec/cloud_controller_ng/bpm_spec.rb
@@ -112,33 +112,40 @@ module Bosh
             end
           end
 
-          context 'when the puma webserver is used' do
-            it 'mounts the valkey volume into the ccng job container' do
-              template_hash = YAML.safe_load(template.render({ 'cc' => { 'experimental' => { 'use_puma_webserver' => true } } }, consumes: {}))
+          describe 'valkey config' do
+            context 'when the puma webserver is used' do
+              it 'mounts the valkey volume into the ccng job container' do
+                template_hash = YAML.safe_load(template.render({}, consumes: {}))
 
-              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-              expect(results.length).to eq(1)
-              expect(valkey_volume_mounted?(results[0])).to be_truthy
+                results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+                expect(results.length).to eq(1)
+                expect(valkey_volume_mounted?(results[0])).to be_truthy
+              end
             end
-          end
 
-          context "when 'cc.experimental.use_redis' is set to 'true'" do
-            it 'mounts the valkey volume into the ccng job container' do
-              template_hash = YAML.safe_load(template.render({ 'cc' => { 'experimental' => { 'use_redis' => true } } }, consumes: {}))
+            context 'when thin webserver is used' do
+              context "when 'cc.experimental.use_redis' is set to 'true'" do
+                it 'mounts the valkey volume into the ccng job container' do
+                  template_hash = YAML.safe_load(
+                    template.render({ 'cc' => { 'temporary_enable_deprecated_thin_webserver' => true,
+                                                'experimental' => { 'use_redis' => true } } }, consumes: {})
+                  )
 
-              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-              expect(results.length).to eq(1)
-              expect(valkey_volume_mounted?(results[0])).to be_truthy
-            end
-          end
+                  results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+                  expect(results.length).to eq(1)
+                  expect(valkey_volume_mounted?(results[0])).to be_truthy
+                end
+              end
 
-          context "when neither the puma webserver is used nor 'cc.experimental.use_redis' is set to 'true'" do
-            it 'does not mount the valkey volume into the ccng job container' do
-              template_hash = YAML.safe_load(template.render({}, consumes: {}))
+              context "when 'cc.experimental.use_redis' is not set'" do
+                it 'mounts the valkey volume into the ccng job container' do
+                  template_hash = YAML.safe_load(template.render({ 'cc' => { 'temporary_enable_deprecated_thin_webserver' => true } }, consumes: {}))
 
-              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-              expect(results.length).to eq(1)
-              expect(valkey_volume_mounted?(results[0])).to be_falsey
+                  results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+                  expect(results.length).to eq(1)
+                  expect(valkey_volume_mounted?(results[0])).to be_falsey
+                end
+              end
             end
           end
         end

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -53,6 +53,7 @@ module Bosh
                         'private_endpoint' => 'https://blobstore.service.cf.internal:4443',
                         'public_endpoint' => 'https://blobstore.brook-sentry.capi.land',
                         'username' => 'blobstore-user' } },
+                'experimental' => {},
                 'install_buildpacks' =>
                   [{ 'name' => 'staticfile_buildpack', 'package' => 'staticfile-buildpack' },
                    { 'name' => 'java_buildpack', 'package' => 'java-buildpack' },
@@ -104,8 +105,7 @@ module Bosh
                   [{ 'description' => 'Cloud Foundry Linux-based filesystem',
                      'name' => 'cflinuxfs4' }],
                 'staging_upload_password' => '((cc_staging_upload_password))',
-                'staging_upload_user' => 'staging_user',
-                'experimental' => {} },
+                'staging_upload_user' => 'staging_user' },
             'ccdb' =>
               { 'databases' => [{ 'name' => 'cloud_controller', 'tag' => 'cc' }],
                 'db_scheme' => 'mysql',

--- a/spec/valkey/monit_spec.rb
+++ b/spec/valkey/monit_spec.rb
@@ -12,7 +12,7 @@ module Bosh
         let(:job) { release.job('valkey') }
         let(:spec) { job.instance_variable_get(:@spec) }
         let(:job_path) { job.instance_variable_get(:@job_path) }
-        let(:cc_internal_properties) { { 'cc' => { 'experimental' => { 'use_puma_webserver' => false, 'use_redis' => false } } } }
+        let(:cc_internal_properties) { { 'cc' => { 'temporary_enable_deprecated_thin_webserver' => false, 'experimental' => { 'use_redis' => false } } } }
         let(:link) { Link.new(name: 'cloud_controller_internal', properties: cc_internal_properties) }
 
         describe 'monit' do
@@ -20,24 +20,27 @@ module Bosh
 
           context 'when the puma webserver is used' do
             it 'renders the monit directives' do
-              cc_internal_properties['cc']['experimental']['use_puma_webserver'] = true
               result = template.render({}, consumes: [link])
               expect(result).to include('check process valkey')
             end
           end
 
-          context "when 'cc.experimental.use_redis' is set to 'true'" do
-            it 'renders the monit directives' do
-              cc_internal_properties['cc']['experimental']['use_redis'] = true
-              result = template.render({}, consumes: [link])
-              expect(result).to include('check process valkey')
+          context 'when thin webserver is used' do
+            context "when 'cc.experimental.use_redis' is set to 'true'" do
+              it 'renders the monit directives' do
+                cc_internal_properties['cc']['temporary_enable_deprecated_thin_webserver'] = true
+                cc_internal_properties['cc']['experimental']['use_redis'] = true
+                result = template.render({}, consumes: [link])
+                expect(result).to include('check process valkey')
+              end
             end
-          end
 
-          context "when neither the puma webserver is used nor 'cc.experimental.use_redis' is set to 'true'" do
-            it 'does not render the monit directives' do
-              result = template.render({}, consumes: [link])
-              expect(result.strip).to eq('')
+            context "when 'cc.experimental.use_redis' is set to 'false'" do
+              it 'does not render the monit directives' do
+                cc_internal_properties['cc']['temporary_enable_deprecated_thin_webserver'] = true
+                result = template.render({}, consumes: [link])
+                expect(result.strip).to eq('')
+              end
             end
           end
         end


### PR DESCRIPTION
### A short explanation of the proposed change:
Make Puma the default webserver as it has been running on big foundations and brings performance boosts, better resource utilization and is well maintained. Thin can be still enabled by using the newly introduced config parameter `cc. temporary_enable_deprecated_thin_webserver `. `jemalloc` is now enabled globally for all CAPI jobs providing better memory management.

- Config `cc.experimental.use_puma_webserver` has been removed
- Config `cc.experimental.use_jemalloc_memory_allocator` has been removed
- Puma default config is 2 workers with each 10 threads and 10 DB connections

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
