### PR TITLE
Revert "Make puma default webserver (#481)"

### DIFF
--- a/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
+++ b/jobs/cc_deployment_updater/templates/bin/cc_deployment_updater.erb
@@ -7,6 +7,8 @@ cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 export RUBYOPT='--yjit'
 <% end %>
 
-export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
+  export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 exec bundle exec rake deployment_updater:start

--- a/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
+++ b/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
@@ -7,6 +7,8 @@ cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 export RUBYOPT='--yjit'
 <% end %>
 
+<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 exec bundle exec rake clock:start

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -163,6 +163,7 @@ provides:
   - cc.external_port
   - cc.external_protocol
   - cc.experimental.use_yjit_compiler
+  - cc.experimental.use_jemalloc_memory_allocator
   - cc.internal_service_hostname
   - cc.jobs.enable_dynamic_job_priorities
   - cc.log_db_queries
@@ -223,11 +224,11 @@ provides:
   - ssl.skip_cert_verify
   - system_domain
   - uaa.clients.cc_routing.secret
+  - cc.experimental.use_puma_webserver
   - cc.experimental.use_redis
   - cc.app_log_revision
   - cc.app_instance_stopping_state
   - cc.deprecated_stacks
-  - cc.temporary_enable_deprecated_thin_webserver
   
 consumes:
 - name: database
@@ -1252,21 +1253,28 @@ properties:
     description: "Use Ruby's YJIT compiler when running Cloud Controller API servers and workers. This feature is experimental and not recommended. Please review the drawbacks and benefits of YJIT before enabling."
     default: false
 
+  cc.experimental.use_jemalloc_memory_allocator:
+    description: "Enables jemalloc rather than malloc for Cloud Controller API servers and workers; however, it's experimental and not typically recommended, so review its pros and cons before use."
+    default: false
+
+  cc.experimental.use_puma_webserver:
+    description: "Use Puma in place of Thin as the webserver. This may increase performance as Puma forks Cloud Controller processes to avoid relying on threads"
+    default: false
+
   cc.experimental.use_redis:
     description: "Use co-deployed Valkey (Redis fork) for rate limiting and metrics. If the Puma webserver is enabled, Valkey will automatically be used."
     default: false
 
   cc.puma.workers:
     description: "Number of workers for Puma webserver."
-    default: 2
+    default: 3
 
   cc.puma.max_threads:
     description: "Maximum number of threads per Puma webserver worker."
-    default: 10
+    default: 2
 
   cc.puma.max_db_connections_per_process:
-    description: "Maximum database connections for Puma per process (main + Puma workers)."
-    default: 10
+    description: "Maximum database connections for Puma per process (main + Puma workers), if not set the ccng value is used (default)"
 
   cc.update_metric_tags_on_rename:
     description: "Enable sending a Desired LRP update when an app is renamed"
@@ -1274,8 +1282,4 @@ properties:
 
   cc.legacy_md5_buildpack_paths_enabled:
     description: "Enable legacy MD5 buildpack paths. If disabled, xxhash64 is used for calculating paths in buildpack image layers."
-    default: false
-
-  cc.temporary_enable_deprecated_thin_webserver:
-    description: "Use deprecated Thin webserver. Please note that when using Thin instead of Puma you miss out on the following benefits: Better resource utilization, well maintained and more performant. Thin will be removed in a future release."
     default: false

--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -18,7 +18,9 @@ echo 'Finished migrations and seeds'
 export RUBYOPT='--yjit'
 <% end %>
 
+<% if p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 exec /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller \
   -c /var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml

--- a/jobs/cloud_controller_ng/templates/bin/local_worker.erb
+++ b/jobs/cloud_controller_ng/templates/bin/local_worker.erb
@@ -9,7 +9,9 @@ wait_for_blobstore
 export RUBYOPT='--yjit'
 <% end %>
 
+<% if p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 exec bundle exec rake "jobs:local[cc_api_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]"

--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -13,7 +13,7 @@ def mount_nfs_volume!(config)
 end
 
 def mount_valkey_volume!(config)
-  unless p("cc.temporary_enable_deprecated_thin_webserver") && !p("cc.experimental.use_redis")
+  if p("cc.experimental.use_puma_webserver") || p("cc.experimental.use_redis")
     config['additional_volumes'] = [] unless config.key?('additional_volumes')
     config['additional_volumes'] << {
       "path" => "/var/vcap/data/valkey",

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -53,7 +53,7 @@ local_route: <%= p('cc.nginx.ip') %>
 external_port: <%= p("cc.external_port") %>
 tls_port: <%= p("cc.tls_port") %>
 internal_service_hostname: <%= p("cc.internal_service_hostname") %>
-webserver: <%= p("cc.temporary_enable_deprecated_thin_webserver") ? 'thin' : 'puma' %>
+webserver: <%= p("cc.experimental.use_puma_webserver") ? 'puma' : 'thin' %>
 puma:
   workers: <%= p("cc.puma.workers") %>
   max_threads: <%= p("cc.puma.max_threads") %>
@@ -490,7 +490,7 @@ rate_limiter_v2_api:
 
 temporary_enable_v2: <%= p("cc.temporary_enable_v2") %>
 
-<% unless p("cc.temporary_enable_deprecated_thin_webserver") && !p("cc.experimental.use_redis") %>
+<% if p("cc.experimental.use_puma_webserver") || p("cc.experimental.use_redis") %>
 redis:
   socket: "/var/vcap/data/valkey/valkey.sock"
 <% end %>

--- a/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
+++ b/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
@@ -9,7 +9,9 @@ wait_for_blobstore
 export RUBYOPT='--yjit'
 <% end %>
 
+<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
 export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 

--- a/jobs/rotate_cc_database_key/templates/bin/run.erb
+++ b/jobs/rotate_cc_database_key/templates/bin/run.erb
@@ -2,7 +2,9 @@
 
 set -eu
 
-export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% if link("cloud_controller_internal").p('cc.experimental.use_jemalloc_memory_allocator') %>
+  export LD_PRELOAD=/var/vcap/packages/jemalloc/lib/libjemalloc.so
+<% end %>
 
 rotate() {
   export CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/rotate_cc_database_key/config/cloud_controller_ng.yml

--- a/jobs/valkey/monit
+++ b/jobs/valkey/monit
@@ -1,6 +1,6 @@
 <%
   cloud_controller_internal = link("cloud_controller_internal")
-  unless cloud_controller_internal.p("cc.temporary_enable_deprecated_thin_webserver") && !cloud_controller_internal.p("cc.experimental.use_redis")
+  if cloud_controller_internal.p("cc.experimental.use_puma_webserver") || cloud_controller_internal.p("cc.experimental.use_redis")
 %>
 
 check process valkey

--- a/spec/cloud_controller_ng/bpm_spec.rb
+++ b/spec/cloud_controller_ng/bpm_spec.rb
@@ -112,40 +112,33 @@ module Bosh
             end
           end
 
-          describe 'valkey config' do
-            context 'when the puma webserver is used' do
-              it 'mounts the valkey volume into the ccng job container' do
-                template_hash = YAML.safe_load(template.render({}, consumes: {}))
+          context 'when the puma webserver is used' do
+            it 'mounts the valkey volume into the ccng job container' do
+              template_hash = YAML.safe_load(template.render({ 'cc' => { 'experimental' => { 'use_puma_webserver' => true } } }, consumes: {}))
 
-                results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-                expect(results.length).to eq(1)
-                expect(valkey_volume_mounted?(results[0])).to be_truthy
-              end
+              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+              expect(results.length).to eq(1)
+              expect(valkey_volume_mounted?(results[0])).to be_truthy
             end
+          end
 
-            context 'when thin webserver is used' do
-              context "when 'cc.experimental.use_redis' is set to 'true'" do
-                it 'mounts the valkey volume into the ccng job container' do
-                  template_hash = YAML.safe_load(
-                    template.render({ 'cc' => { 'temporary_enable_deprecated_thin_webserver' => true,
-                                                'experimental' => { 'use_redis' => true } } }, consumes: {})
-                  )
+          context "when 'cc.experimental.use_redis' is set to 'true'" do
+            it 'mounts the valkey volume into the ccng job container' do
+              template_hash = YAML.safe_load(template.render({ 'cc' => { 'experimental' => { 'use_redis' => true } } }, consumes: {}))
 
-                  results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-                  expect(results.length).to eq(1)
-                  expect(valkey_volume_mounted?(results[0])).to be_truthy
-                end
-              end
+              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+              expect(results.length).to eq(1)
+              expect(valkey_volume_mounted?(results[0])).to be_truthy
+            end
+          end
 
-              context "when 'cc.experimental.use_redis' is not set'" do
-                it 'mounts the valkey volume into the ccng job container' do
-                  template_hash = YAML.safe_load(template.render({ 'cc' => { 'temporary_enable_deprecated_thin_webserver' => true } }, consumes: {}))
+          context "when neither the puma webserver is used nor 'cc.experimental.use_redis' is set to 'true'" do
+            it 'does not mount the valkey volume into the ccng job container' do
+              template_hash = YAML.safe_load(template.render({}, consumes: {}))
 
-                  results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-                  expect(results.length).to eq(1)
-                  expect(valkey_volume_mounted?(results[0])).to be_falsey
-                end
-              end
+              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
+              expect(results.length).to eq(1)
+              expect(valkey_volume_mounted?(results[0])).to be_falsey
             end
           end
         end


### PR DESCRIPTION
This reverts commit 781690ed37e2add4ab264e3b268b59d53ca8dd69.

---

While we would like to see Puma be made the default web server, removing this property with no notice is problematic for us as we have non cf-d deployments that consume this property explicitly. Instead, perhaps for now these property defaults could be changed to `true` for a period of releases before being removed in its entirety.

We'd also like to workout a more formal deprecation policy for properties. Additionally, going forward, I think this pattern of including `experimental` in the name of the property only causes problems when we have to eventually remove them and replace them with something else. Perhaps we could have just had `enable_puma` as a property with a textual description stating it was experimental and then eventually remove that phrasing. We can discuss this on the WG call.

@Samze and @sethboyles 


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
