### PR TITLE
Add temporary_enable_v2 flag to cc-worker config

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -211,6 +211,7 @@ provides:
   - cc.statsd_port
   - cc.enable_statsd_metrics
   - cc.system_hostnames
+  - cc.temporary_enable_v2
   - cc.tls_port
   - cc.uaa.client_timeout
   - cc.internal_route_vip_range

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -388,10 +388,6 @@ properties:
     default: false
     description: "Enable development features for monitoring and insight"
 
-  cc.temporary_enable_v2:
-    description: "Enable V2 endpoints"
-    default: true
-
   cc.newrelic.license_key:
     default: ~
     description: "The api key for NewRelic"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -388,6 +388,10 @@ properties:
     default: false
     description: "Enable development features for monitoring and insight"
 
+  cc.temporary_enable_v2:
+    description: "Enable V2 endpoints"
+    default: true
+
   cc.newrelic.license_key:
     default: ~
     description: "The api key for NewRelic"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -128,6 +128,8 @@ db: &db
 
 <% system_domain = p("system_domain") %>
 
+temporary_enable_v2: <%= p("cc.temporary_enable_v2") %>
+
 uaa:
   internal_url: <%= "https://#{p("cc.uaa.internal_url")}:#{p("uaa.ssl.port")}" %>
   ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/uaa_ca.crt

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -128,7 +128,7 @@ db: &db
 
 <% system_domain = p("system_domain") %>
 
-temporary_enable_v2: <%= p("cc.temporary_enable_v2") %>
+temporary_enable_v2: <%= link("cloud_controller_internal").p("cc.temporary_enable_v2") %>
 
 uaa:
   internal_url: <%= "https://#{p("cc.uaa.internal_url")}:#{p("uaa.ssl.port")}" %>

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -80,10 +80,12 @@ module Bosh
               'jobs' => {
                 'enable_dynamic_job_priorities' => false
               },
-              'app_log_revision' => true
+              'app_log_revision' => true,
+              'temporary_enable_v2' => true
             }
           }
         end
+
         let(:cloud_controller_internal_link) do
           Link.new(name: 'cloud_controller_internal', properties:, instances: [LinkInstance.new(address: 'default_app_ssh_access')])
         end
@@ -263,17 +265,6 @@ module Bosh
           it 'is by default true' do
             template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
             expect(template_hash['temporary_enable_v2']).to be(true)
-          end
-
-          context 'when explicitly disabled' do
-            before do
-              manifest_properties['cc']['temporary_enable_v2'] = false
-            end
-
-            it 'is false' do
-              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
-              expect(template_hash['temporary_enable_v2']).to be(false)
-            end
           end
         end
       end

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -258,6 +258,24 @@ module Bosh
             end
           end
         end
+
+        describe 'enable v2 API' do
+          it 'is by default true' do
+            template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+            expect(template_hash['temporary_enable_v2']).to be(true)
+          end
+
+          context 'when explicitly disabled' do
+            before do
+              manifest_properties['cc']['temporary_enable_v2'] = false
+            end
+
+            it 'is false' do
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['temporary_enable_v2']).to be(false)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* A short explanation of the proposed change:
Add `temporary_enable_v2` config flag to cc-worker configuration. Required for service broker client fix: https://github.com/cloudfoundry/cloud_controller_ng/pull/4058

* An explanation of the use cases your change solves
Part of v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4058

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
-> ran tests on new "gyro" env: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/gyro-exp-tests/builds/5
Test suite is basically green with this PR. The 4 failing tests must be fixed in CATs.
