### PR TITLE
Add config for shadow user creation

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1002,6 +1002,9 @@ properties:
   uaa.clients.cloud_controller_username_lookup.secret:
     description: "Used for fetching usernames from UAA"
 
+  uaa.clients.cloud_controller_shadow_user_creation.secret:
+    description: "Used for creating UAA shadow users when `cc.allow_user_creation_by_org_manager` is enabled."
+
   uaa.clients.cc_service_key_client.secret:
     description: "Used for fetching service key values from CredHub"
 
@@ -1282,6 +1285,8 @@ properties:
     description: "Use deprecated Thin webserver. Please note that when using Thin instead of Puma you miss out on the following benefits: Better resource utilization, well maintained and more performant. Thin will be removed in a future release. `cc.experimental.use_puma_webserver` takes precedence over this."
     default: false
 
+  cc.allow_user_creation_by_org_manager:
+    description: "Allow org managers to explicitly create UAA shadow users through /v3/users and implicitly through /v3/roles. `uaa.clients.cloud_controller_shadow_user_creation.secret` must be set."
 
 # deprecated configuration
 

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -255,6 +255,12 @@ uaa:
   <% if_p("uaa.cc.token_secret2") do |token_secret2| %>
   symmetric_secret2: "<%= token_secret2 %>"
   <% end %>
+  clients:
+  <% if_p("uaa.clients.cloud_controller_shadow_user_creation.secret") do |secret| %>
+  - name: "cloud_controller_shadow_user_creation"
+    id: "cloud_controller_shadow_user_creation"
+    secret: <%= secret %>
+  <% end %>
 
 <% if p("routing_api.enabled") %>
 routing_api:
@@ -561,3 +567,7 @@ threadpool_size: <%= p("cc.experimental.thin_server.thread_pool_size") %>
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: <%= p("cc.custom_metric_tag_prefix_list") %>
 update_metric_tags_on_rename: <%= p("cc.update_metric_tags_on_rename") %>
+
+<% if_p("cc.allow_user_creation_by_org_manager") do |allow_user_creation| %>
+allow_user_creation_by_org_manager: <%= allow_user_creation %>
+<% end %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -850,6 +850,59 @@ module Bosh
               end
             end
           end
+
+          describe 'allow_user_creation_by_org_manager' do
+            context 'when it is not set' do
+              it 'does not render into the config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['allow_user_creation_by_org_manager']).to be_nil
+              end
+            end
+
+            context 'when it is set to false' do
+              before do
+                merged_manifest_properties['cc']['allow_user_creation_by_org_manager'] = false
+              end
+
+              it 'renders it as false' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['allow_user_creation_by_org_manager']).to be(false)
+              end
+            end
+
+            context 'when it is set to true' do
+              before do
+                merged_manifest_properties['cc']['allow_user_creation_by_org_manager'] = true
+              end
+
+              it 'renders it as true' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['allow_user_creation_by_org_manager']).to be(true)
+              end
+            end
+          end
+
+          describe 'uaa.clients.cloud_controller_shadow_user_creation.secret' do
+            context 'when it is not set' do
+              it 'does not render the client into the config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['uaa']['clients']).to be_nil
+              end
+            end
+
+            context 'when it is set' do
+              before do
+                merged_manifest_properties['uaa']['clients'].merge!({ 'cloud_controller_shadow_user_creation' => { 'secret' => 'super-secret' } })
+              end
+
+              it 'renders the client and secret into the config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                client = template_hash['uaa']['clients'].find { |client_config| client_config['name'] == 'cloud_controller_shadow_user_creation' }
+                expect(client['id']).to eq('cloud_controller_shadow_user_creation')
+                expect(client['secret']).to eq('super-secret')
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
### A short explanation of the proposed change:

This PR adds a config parameter and UAA client for shadow user creation described in https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0033-user-creation-by-org-managers.md

- Add UAA client to ccng
- Add `allow_user_creation_by_org_manager` config

### Links to any other associated PRs
PR in ccng: https://github.com/cloudfoundry/cloud_controller_ng/pull/4113

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
