### PR TITLE
Add "max_valid_packages_stored" config param to worker template

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -181,6 +181,7 @@ provides:
   - cc.packages.fog_gcp_storage_options
   - cc.packages.fog_connection
   - cc.packages.max_package_size
+  - cc.packages.max_valid_packages_stored
   - cc.packages.webdav_config.blobstore_timeout
   - cc.packages.webdav_config.ca_cert
   - cc.packages.webdav_config.password

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -186,6 +186,7 @@ packages:
     <% end %>
   app_package_directory_key: <%= p("cc.packages.app_package_directory_key") %>
   max_package_size: <%= p("cc.packages.max_package_size") %>
+  max_valid_packages_stored: <%= link("cloud_controller_internal").p("cc.packages.max_valid_packages_stored") %>
   <% if_p("cc.packages.cdn") do %>
   cdn:
     uri: <%= p("cc.packages.cdn.uri") %>

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -81,7 +81,10 @@ module Bosh
                 'enable_dynamic_job_priorities' => false
               },
               'app_log_revision' => true,
-              'temporary_enable_v2' => true
+              'temporary_enable_v2' => true,
+              'packages' => {
+                'max_valid_packages_stored' => 5
+              }
             }
           }
         end
@@ -265,6 +268,13 @@ module Bosh
           it 'is by default true' do
             template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
             expect(template_hash['temporary_enable_v2']).to be(true)
+          end
+        end
+
+        describe 'max valid packages stored' do
+          it 'is set from cloud_controller_internal_link' do
+            template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+            expect(template_hash['packages']['max_valid_packages_stored']).to be(5)
           end
         end
       end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add the config parameter "max_valid_packages_stored" to the "cloud_controller_worker" job.

* An explanation of the use cases your change solves
This is needed for https://github.com/cloudfoundry/cloud_controller_ng/pull/4111.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4116

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite -> ran "include_apps" suite on GCP dev environment
