### PR TITLE
Draining CC-api VMs should let local-worker jobs finish

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -948,6 +948,9 @@ properties:
   cc.jobs.local.number_of_workers:
     default: 2
     description: "Number of local cloud_controller_worker workers"
+  cc.jobs.local.local_worker_grace_period_seconds:
+    default: 300
+    description:  "The number of seconds to wait for each local cloud_controller_worker worker process to finish processing jobs before forcefully shutting it down"
 
   cc.thresholds.api.alert_if_above_mb:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"

--- a/jobs/cloud_controller_ng/templates/drain.sh.erb
+++ b/jobs/cloud_controller_ng/templates/drain.sh.erb
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-for i in {1..<%=p("cc.jobs.local.number_of_workers")%>}; do
-  /var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p "local_worker_${i}" 1>&2
-done
-
 /var/vcap/jobs/cloud_controller_ng/bin/shutdown_drain 1>&2
 
 echo 0 # tell bosh not wait for anything

--- a/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
+++ b/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
@@ -8,3 +8,10 @@ require 'cloud_controller/drain'
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cloud_controller_ng')
 @drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', <%= p("cc.nginx_drain_timeout") %>)
 @drain.shutdown_cc('/var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid')
+@threads = []
+@grace_period_in_seconds = <%= p("cc.jobs.local.local_worker_grace_period_seconds") %>
+(1..<%= p("cc.jobs.local.number_of_workers") %>).each do |i|
+  @threads << Thread.new { @drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cloud_controller_ng/local_worker_#{i}.pid", @grace_period_in_seconds.to_i) }
+end
+
+@threads.each(&:join)

--- a/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
+++ b/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
@@ -9,9 +9,9 @@ require 'cloud_controller/drain'
 @drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', <%= p("cc.nginx_drain_timeout") %>)
 @drain.shutdown_cc('/var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid')
 @threads = []
-@grace_period_in_seconds = <%= p("cc.jobs.local.local_worker_grace_period_seconds") %>
+@local_worker_grace_period_seconds = <%= p("cc.jobs.local.local_worker_grace_period_seconds") %>
 (1..<%= p("cc.jobs.local.number_of_workers") %>).each do |i|
-  @threads << Thread.new { @drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cloud_controller_ng/local_worker_#{i}.pid", @grace_period_in_seconds.to_i) }
+  @threads << Thread.new { @drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cloud_controller_ng/local_worker_#{i}.pid", @local_worker_grace_period_seconds.to_i) }
 end
 
 @threads.each(&:join)

--- a/spec/cloud_controller_ng/drain_spec.rb
+++ b/spec/cloud_controller_ng/drain_spec.rb
@@ -19,6 +19,13 @@ module Bosh
             expect(rendered_file).to include("@drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', 30)")
           end
 
+          context "when 'local_worker_grace_period_seconds' is provided" do
+            it 'renders the provided value' do
+              rendered_file = template.render({ 'cc' => { 'jobs' => { 'local' => { 'worker_grace_period_seconds' => 300 } } } }, consumes: {})
+              expect(rendered_file).to include('@local_worker_grace_period_seconds = 300')
+            end
+          end
+
           context 'when nginx timeout is provided' do
             it 'renders the provided value' do
               rendered_file = template.render({ 'cc' => { 'nginx_drain_timeout' => 60 } }, consumes: {})

--- a/spec/cloud_controller_ng/drain_spec.rb
+++ b/spec/cloud_controller_ng/drain_spec.rb
@@ -26,6 +26,13 @@ module Bosh
             end
           end
 
+          context "when 'local.number_of_workers' is provided" do
+            it 'renders the provided number of workers' do
+              rendered_file = template.render({ 'cc' => { 'jobs' => { 'local' => { 'number_of_workers' => 5 } } } }, consumes: {})
+              expect(rendered_file).to include('(1..5).each do |i|')
+            end
+          end
+
           context 'when nginx timeout is provided' do
             it 'renders the provided value' do
               rendered_file = template.render({ 'cc' => { 'nginx_drain_timeout' => 60 } }, consumes: {})


### PR DESCRIPTION
**A short explanation of the proposed change:**

In case of a graceful shutdown of a CC api VM, local-worker will wait before shutdown if there are still jobs running on the local-worker queue. The default grace period is set to 5 minutes, it is configurable by setting a value for: ```cc.jobs.local.local_worker_grace_period_seconds```.   

The order of the shutdown is now:
- shutdown nginx
- shutdown cloud_controller
- shutdown local_worker
  
Before the order was shutdown local_worker, then nginx, then cloud_controller.  


**An explanation of the use cases your change solves:**
It seems that a graceful shutdown of a CC API VM (e.g., during an update) does not properly account for draining the worker jobs on the API VM that handle file uploads. 
When the CC API VM is restarted or recreated while a local worker on the API VM is processing an upload job—transferring files from disk to the blobstore—the package status gets stuck in PROCESSING_UPLOAD. The upload job seems to have the standard timeout of 4h configured - which leads to hanging deployments that are stopped finally by client side timeouts. 
With the proposed change the local-worker will wait for 5 minutes if there are still jobs running, until shutdown is performed. That will give the upload job more time to finish.

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
