### PR TITLE
Explicitly configure worker sleep delay

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -371,6 +371,9 @@ properties:
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overridden per job"
     default: 14400 # 4 hours
+  cc.jobs.global.worker_sleep_delay_in_seconds:
+    description: "The amount of time in seconds delayed workers sleep when no jobs are found"
+    default: 5
   cc.jobs.queues.cc_generic.timeout_in_seconds:
     description: "The longest jobs in the cc-generic queue can take before they are cancelled"
   cc.jobs.blobstore_delete.timeout_in_seconds:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -91,6 +91,7 @@ jobs:
   enable_dynamic_job_priorities: <%= p("cc.jobs.enable_dynamic_job_priorities") %>
   global:
     timeout_in_seconds: <%= p("cc.jobs.global.timeout_in_seconds") %>
+    worker_sleep_delay_in_seconds: <%= p("cc.jobs.global.worker_sleep_delay_in_seconds") %>
   queues:
     <% if (timeout = p("cc.jobs.queues.cc_generic.timeout_in_seconds", nil)) %>
     cc_generic:

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -84,6 +84,9 @@ properties:
   cc.jobs.global.timeout_in_seconds:
     description: "The longest any job can take before it is cancelled unless overriden per job"
     default: 14400 # 4 hours
+  cc.jobs.global.worker_sleep_delay_in_seconds:
+    description: "The amount of time in seconds delayed workers sleep when no jobs are found"
+    default: 5
   cc.jobs.blobstore_delete.timeout_in_seconds:
     description: "The longest this job can take before it is cancelled"
 

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -47,6 +47,7 @@ jobs:
   enable_dynamic_job_priorities: <%= link("cloud_controller_internal").p("cc.jobs.enable_dynamic_job_priorities") %>
   global:
     timeout_in_seconds: <%= p("cc.jobs.global.timeout_in_seconds") %>
+    worker_sleep_delay_in_seconds: <%= p("cc.jobs.global.worker_sleep_delay_in_seconds") %>
   queues: {}
   <% if_p("cc.jobs.blobstore_delete.timeout_in_seconds") do |timeout| %>
   blobstore_delete:


### PR DESCRIPTION
Allows operators to provide a different sleep delay for the delayed workers. This can be used to e.g. reduce the database load of the delayed_jobs table.

Related to https://github.com/cloudfoundry/cloud_controller_ng/pull/4149

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
