### PR TITLE
Allow configuring Puma to set worker count to number of detected cores

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1262,6 +1262,10 @@ properties:
     description: "Use co-deployed Valkey (Redis fork) for rate limiting and metrics. If the Puma webserver is enabled, Valkey will automatically be used."
     default: false
 
+  cc.puma.automatic_worker_count:
+    description: "Sets the number of Puma workers to the number of detected cores.  See https://github.com/puma/puma?tab=readme-ov-file#clustered-mode for information on how cores are detected. If set to 'true', the value set for `cc.puma.workers` will be ignored."
+    default: false
+
   cc.puma.workers:
     description: "Number of workers for Puma webserver."
     default: 2

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -63,6 +63,7 @@ tls_port: <%= p("cc.tls_port") %>
 internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 webserver: <%= thin_webserver_enabled? ? 'thin' : 'puma' %>
 puma:
+  automatic_worker_count: <%= p("cc.puma.automatic_worker_count") %>
   workers: <%= p("cc.puma.workers") %>
   max_threads: <%= p("cc.puma.max_threads") %>
 <% if_p("cc.puma.max_db_connections_per_process") do |max_db_conn_per_process| %>


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/pull/4166

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
