### PR TITLE
Disable v2 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ blobs
 .final_builds/jobs/**/*.tgz
 .final_builds/packages/**/*.tgz
 .bundle/
+.vscode/
 *.swp
 *~
 *#

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -395,7 +395,7 @@ properties:
 
   cc.temporary_enable_v2:
     description: "Enable V2 endpoints"
-    default: true
+    default: false
 
   cc.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_ng/tmp"

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -106,7 +106,7 @@ module Bosh
                      'name' => 'cflinuxfs4' }],
                 'staging_upload_password' => '((cc_staging_upload_password))',
                 'staging_upload_user' => 'staging_user',
-                'temporary_enable_v2' => true },
+                'temporary_enable_v2' => false },
             'ccdb' =>
               { 'databases' => [{ 'name' => 'cloud_controller', 'tag' => 'cc' }],
                 'db_scheme' => 'mysql',
@@ -503,19 +503,19 @@ module Bosh
           end
 
           describe 'enable v2 API' do
-            it 'is by default true' do
+            it 'is by default false' do
               template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
-              expect(template_hash['temporary_enable_v2']).to be(true)
+              expect(template_hash['temporary_enable_v2']).to be(false)
             end
 
-            context 'when explicitly disabled' do
+            context 'when explicitly enabled' do
               before do
-                merged_manifest_properties['cc']['temporary_enable_v2'] = false
+                merged_manifest_properties['cc']['temporary_enable_v2'] = true
               end
 
-              it 'is false' do
+              it 'is true' do
                 template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
-                expect(template_hash['temporary_enable_v2']).to be(false)
+                expect(template_hash['temporary_enable_v2']).to be(true)
               end
             end
           end

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -81,7 +81,7 @@ module Bosh
                 'enable_dynamic_job_priorities' => false
               },
               'app_log_revision' => true,
-              'temporary_enable_v2' => true,
+              'temporary_enable_v2' => false,
               'packages' => {
                 'max_valid_packages_stored' => 5
               }
@@ -267,7 +267,7 @@ module Bosh
         describe 'enable v2 API' do
           it 'is by default true' do
             template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
-            expect(template_hash['temporary_enable_v2']).to be(true)
+            expect(template_hash['temporary_enable_v2']).to be(false)
           end
         end
 


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Disable v2 by default. Can be re-enabled using `cc.temporary_enable_v2`

* An explanation of the use cases your change solves

See [RFC0032 - CF API v2 End of Life](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md) and https://github.com/cloudfoundry/community/issues/1001

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
