### PR TITLE
Add TLS certs and keys for cc-worker metrics endpoint

### DIFF
--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -32,6 +32,9 @@ templates:
   uaa_ca.crt.erb: config/certs/uaa_ca.crt
   db_ca.crt.erb: config/certs/db_ca.crt
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
+  scrape.crt.erb: config/certs/scrape.crt
+  scrape.key.erb: config/certs/scrape.key
+  scrape_ca.crt.erb: config/certs/scrape_ca.crt
 
 packages:
   - capi_utils
@@ -434,9 +437,16 @@ properties:
   cc.prometheus_port:
     default: 9394
     description: "When 'cc.publish_metrics' is set to true, the webserver, which publishes the metrics, will listen on this port."
+
   cc.prom_scraper.disabled:
     default: false
     description: "When 'cc.publish_metrics' is enabled, a prom_scraper_config will be automatically generated. If you want to use another component for scraping, you can disable scraping by prom_scraper for cc-worker metrics with this."
+  cc.prom_scraper_tls.ca_cert:
+    description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication with prom_scraper"
+  cc.prom_scraper_tls.public_cert:
+    description: "PEM-encoded certificate for secure, mutually authenticated TLS communication with prom_scraper"
+  cc.prom_scraper_tls.private_key:
+    description: "PEM-encoded key for secure, mutually authenticated TLS communication with prom_scraper"
 
   cc.directories.tmpdir:
     default: "/var/vcap/data/cloud_controller_worker/tmp"

--- a/jobs/cloud_controller_worker/templates/prom_scraper_config.yml.erb
+++ b/jobs/cloud_controller_worker/templates/prom_scraper_config.yml.erb
@@ -2,6 +2,7 @@
 port: <%= p("cc.prometheus_port") %>
 source_id: "cloud_controller_worker"
 instance_id: <%= spec.id || spec.index.to_s %>
-scheme: http
+scheme: https
+server_name: "cc_worker_metrics"
 path: /metrics
 <% end -%>

--- a/jobs/cloud_controller_worker/templates/scrape.crt.erb
+++ b/jobs/cloud_controller_worker/templates/scrape.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.prom_scraper_tls.public_cert', '') %>

--- a/jobs/cloud_controller_worker/templates/scrape.key.erb
+++ b/jobs/cloud_controller_worker/templates/scrape.key.erb
@@ -1,0 +1,1 @@
+<%= p('cc.prom_scraper_tls.private_key', '') %>

--- a/jobs/cloud_controller_worker/templates/scrape_ca.crt.erb
+++ b/jobs/cloud_controller_worker/templates/scrape_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.prom_scraper_tls.ca_cert', '') %>


### PR DESCRIPTION
### A short explanation of the proposed change:
Add certs and keys to enable mTLS communication between cc-worker metrics endpoint and scraper.
### An explanation of the use cases your change solves

### Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4214
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
