### PR TITLE
Add label 'origin: cc_worker' to cc-worker's prom_scraper config

### DIFF
--- a/jobs/cloud_controller_worker/templates/prom_scraper_config.yml.erb
+++ b/jobs/cloud_controller_worker/templates/prom_scraper_config.yml.erb
@@ -5,4 +5,6 @@ instance_id: <%= spec.id || spec.index.to_s %>
 scheme: https
 server_name: "cc_worker_metrics"
 path: /metrics
+labels:
+  origin: cc_worker
 <% end -%>


### PR DESCRIPTION
* A short explanation of the proposed change:
Add the label `origin: cc_worker` to prom_scraper config of cc-worker.
* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
