### PR TITLE
New config: cc.jobs.read_ahead

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -84,6 +84,8 @@ properties:
     default: 600
   cc.jobs.priorities:
     description: "List of hashes containing delayed jobs 'display_name' and its desired priority. This will overwrite the default priority of ccng"
+  cc.jobs.read_ahead:
+    description: "The number of jobs to read ahead from the delayed job queue. Defaults to 5 for MySql and 0 for PostgreSQL (= use SELECT FOR UPDATE instead of read-ahead)."
 
   cc.max_retained_deployments_per_app:
     description: "The number of inactive deployments to keep for each app"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -62,6 +62,9 @@ jobs:
   <% if_p("cc.jobs.priorities") do |priorities| %>
   priorities: <%= priorities.to_json %>
   <% end %>
+  <% if_p("cc.jobs.read_ahead") do |read_ahead| %>
+  read_ahead: <%= read_ahead %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -388,6 +388,8 @@ properties:
     default: false
   cc.jobs.number_of_worker_threads:
     description: "If set multiple delayed job workers will be started as threads in the same process. If not set there will be one delayed job worker per process."
+  cc.jobs.read_ahead:
+    description: "The number of jobs to read ahead from the delayed job queue. Defaults to 5 for MySql and 0 for PostgreSQL (= use SELECT FOR UPDATE instead of read-ahead)."
 
   cc.temporary_disable_deployments:
     description: "Do not allow the API client to create app deployments (temporary)"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -111,6 +111,9 @@ jobs:
   <% if_p("cc.jobs.priorities") do |priorities| %>
   priorities: <%= priorities.to_json %>
   <% end %>
+  <% if_p("cc.jobs.read_ahead") do |read_ahead| %>
+  read_ahead: <%= read_ahead %>
+  <% end %>
 
 
 cpu_weight_min_memory: <%= p("cc.cpu_weight_min_memory") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -93,6 +93,8 @@ properties:
     default: 5
   cc.jobs.blobstore_delete.timeout_in_seconds:
     description: "The longest this job can take before it is cancelled"
+  cc.jobs.read_ahead:
+    description: "The number of jobs to read ahead from the delayed job queue. Defaults to 5 for MySql and 0 for PostgreSQL (= use SELECT FOR UPDATE instead of read-ahead)."
 
   cc.external_protocol:
     default: "https"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -56,6 +56,9 @@ jobs:
   <% if_p("cc.jobs.priorities") do |priorities| %>
   priorities: <%= priorities.to_json %>
   <% end %>
+  <% if_p("cc.jobs.read_ahead") do |read_ahead| %>
+  read_ahead: <%= read_ahead %>
+  <% end %>
 
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>

--- a/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
+++ b/spec/cloud_controller_clock/cloud_controller_clock_spec.rb
@@ -137,6 +137,16 @@ module Bosh
           end
         end
 
+        describe 'cc.jobs.read_ahead' do
+          context 'when cc.jobs.read_ahead is set to 5' do
+            it 'renders read_ahead into ccng config' do
+              manifest_properties['cc']['jobs'] = { 'read_ahead' => 5 }
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['jobs']['read_ahead']).to be(5)
+            end
+          end
+        end
+
         describe 'statsd' do
           it 'renders statsd_host and statsd_port from cloud_controller_internal link' do
             template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -851,6 +851,16 @@ module Bosh
             end
           end
 
+          describe 'cc.jobs.read_ahead' do
+            context 'when cc.jobs.read_ahead is set to 5' do
+              it 'renders read_ahead into ccng config' do
+                merged_manifest_properties['cc']['jobs'] = { 'read_ahead' => 5 }
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['jobs']['read_ahead']).to be(5)
+              end
+            end
+          end
+
           describe 'allow_user_creation_by_org_manager' do
             context 'when it is not set' do
               it 'does not render into the config' do

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -265,6 +265,16 @@ module Bosh
           end
         end
 
+        describe 'cc.jobs.read_ahead' do
+          context 'when cc.jobs.read_ahead is set to 5' do
+            it 'renders read_ahead into ccng config' do
+              manifest_properties['cc']['jobs'] = { 'read_ahead' => 5 }
+              template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))
+              expect(template_hash['jobs']['read_ahead']).to be(5)
+            end
+          end
+        end
+
         describe 'enable v2 API' do
           it 'is by default true' do
             template_hash = YAML.safe_load(template.render(manifest_properties, consumes: links))


### PR DESCRIPTION
* A short explanation of the proposed change:

The number of jobs to read ahead from the delayed job queue. Defaults to 5 for MySql and 0 for PostgreSQL (= use SELECT FOR UPDATE instead of read-ahead).

Allows lock_with_read_ahead for PostgreSQL to address a severe performance issue under heavy job load.

* An explanation of the use cases your change solves

Using lock_with_for_update showed severe performance problems on postgres when there is a high number of jobs in the queue (>50k). Job processing starves due to row locks and temp IO gets high.
lock_with_read_ahead performs much better under such load situations.

Performance on low/normal job load is comparable.

* Links to any other associated PRs

See also cloudfoundry/cloud_controller_ng#4231

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
