### PR TITLE
Add draining for cc_uploader process

### DIFF
--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -80,4 +80,4 @@ properties:
 
   cc.jobs.cc_uploader.grace_period_seconds:
     description: "Grace period in seconds for cc_uploader to finish ongoing jobs during shutdown"
-    default: 30
+    default: 300

--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -3,6 +3,8 @@ name: cc_uploader
 
 templates:
   bpm.yml.erb: config/bpm.yml
+  drain.sh.erb: bin/drain
+  shutdown_drain.rb.erb: bin/shutdown_drain
 
   cc_uploader_as_vcap.erb: bin/cc_uploader_as_vcap
   cc_uploader_config.json.erb: config/cc_uploader_config.json
@@ -75,3 +77,7 @@ properties:
     description: "PEM-encoded certificate for secure, mutually authenticated TLS communication"
   capi.cc_uploader.mutual_tls.server_key:
     description: "PEM-encoded key for secure, mutually authenticated TLS communication"
+
+  cc.jobs.cc_uploader.grace_period_seconds:
+    description: "Grace period in seconds for cc_uploader to finish ongoing jobs during shutdown"
+    default: 30

--- a/jobs/cc_uploader/templates/drain.sh.erb
+++ b/jobs/cc_uploader/templates/drain.sh.erb
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+/var/vcap/jobs/cc_uploader/bin/shutdown_drain 1>&2
+
+echo 0 # tell bosh not wait for anything
+exit 0

--- a/jobs/cc_uploader/templates/shutdown_drain.rb.erb
+++ b/jobs/cc_uploader/templates/shutdown_drain.rb.erb
@@ -9,5 +9,4 @@ require 'cloud_controller/drain'
 @grace_period = <%= p("cc.jobs.cc_uploader.grace_period_seconds") %>
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cc_uploader')
 
-
-@drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cc_uploader/cc_uploader_#{i}.pid", @grace_period.to_i)
+@drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cc_uploader/cc_uploader.pid", @grace_period.to_i)

--- a/jobs/cc_uploader/templates/shutdown_drain.rb.erb
+++ b/jobs/cc_uploader/templates/shutdown_drain.rb.erb
@@ -1,0 +1,13 @@
+#!/var/vcap/packages/ruby-3.2/bin/ruby --disable-all
+
+$LOAD_PATH.unshift('/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/app')
+$LOAD_PATH.unshift('/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/lib')
+
+require 'cloud_controller/drain'
+
+@threads = []
+@grace_period = <%= p("cc.jobs.cc_uploader.grace_period_seconds") %>
+@drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cc_uploader')
+
+
+@drain.shutdown_delayed_worker("/var/vcap/sys/run/bpm/cc_uploader/cc_uploader_#{i}.pid", @grace_period.to_i)

--- a/spec/cc_uploader/drain_spec.rb
+++ b/spec/cc_uploader/drain_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh
+  module Template
+    module Test
+      describe 'cc_uploader drain template rendering' do
+        let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+        let(:release) { ReleaseDir.new(release_path) }
+        let(:job) { release.job('cc_uploader') }
+
+        describe 'bin/shutdown_drain' do
+          let(:template) { job.template('bin/shutdown_drain') }
+
+          it 'renders the default grace period' do
+            rendered_file = template.render({}, consumes: {})
+            expect(rendered_file).to include('@grace_period = 30')
+          end
+
+          context "when 'grace_period_seconds' is provided" do
+            it 'renders the provided grace period' do
+              rendered_file = template.render({ 'cc' => { 'jobs' => { 'cc_uploader' => { 'grace_period_seconds' => 60 } } } }, consumes: {})
+              expect(rendered_file).to include('@grace_period = 60')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Improve resiliency of droplet upload
* An explanation of the use cases your change solves
For the cc-uploader itself there is no draining in place; the request gets aborted when cc-uploader is stopped. With the change, cc-uploader waits some grace_period_seconds before shutting down.
* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
