### PR TITLE
Let v2/info return information like before if temporary_enable_v2 is true

### DIFF
--- a/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb
@@ -34,7 +34,7 @@ location / {
 }
 
 <% if !p("cc.temporary_enable_v2") %>
-location ~ /v2/ {
+location ~ /v2(?!/info) {
   return 404 "V2 endpoints disabled";
 }
 <% end %>


### PR DESCRIPTION

* A short explanation of the proposed change:
Keep /v2/info endpoint when v2 is disabled
* An explanation of the use cases your change solves
Tools like cf-java-client don't break when v2 info is disabled and they are still using v2/info endpoint

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4280
mainly revert of https://github.com/cloudfoundry/capi-release/pull/480
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
