### PR TITLE
Flag skip_bigint_id_migration

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -729,6 +729,9 @@ properties:
     default: 1800
   ccdb.migration_psql_worker_memory_kb:
     description: "Allows operators to set the worker memory for PostgreSQL database migrations"
+  ccdb.skip_bigint_id_migration:
+    description: "Optionally opt-out of the id (primary key) migration from int to bigint. This must be set before any migration steps have started, otherwise it has no effect."
+    default: false
   ccdb.connection_expiration_timeout:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -246,6 +246,7 @@ db: &db
 max_migration_duration_in_minutes: <%= p("ccdb.max_migration_duration_in_minutes") %>
 max_migration_statement_runtime_in_seconds: <%= p("ccdb.max_migration_statement_runtime_in_seconds") %>
 migration_psql_concurrent_statement_timeout_in_seconds: <%= p("ccdb.migration_psql_concurrent_statement_timeout_in_seconds") %>
+skip_bigint_id_migration: <%= p("ccdb.skip_bigint_id_migration") %>
 login:
   url: <%= p("login.enabled") ? login_url : uaa_url %>
 uaa:


### PR DESCRIPTION
The migration of primary keys from `int` to `bigint` (currently PostgreSQL only, starting with the **events** table) will not be performed when this flag is set to `true`. The default value is `false` meaning the multi-step migration will be started.

Related PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/4281

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
