### PR TITLE
Add cc.enable_ipv6 to config

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1308,6 +1308,9 @@ properties:
   cc.allow_user_creation_by_org_manager:
     description: "Allow org managers to explicitly create UAA shadow users through /v3/users and implicitly through /v3/roles. `uaa.clients.cloud_controller_shadow_user_creation.secret` must be set."
 
+  cc.enable_ipv6:
+    description: "Enable IPv6 support in Cloud Controller."
+
 # deprecated configuration
 
   cc.experimental.use_puma_webserver:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -583,3 +583,7 @@ update_metric_tags_on_rename: <%= p("cc.update_metric_tags_on_rename") %>
 <% if_p("cc.allow_user_creation_by_org_manager") do |allow_user_creation| %>
 allow_user_creation_by_org_manager: <%= allow_user_creation %>
 <% end %>
+
+<% if_p("cc.enable_ipv6") do |enable_ipv6| %>
+enable_ipv6: <%= enable_ipv6 %>
+<% end %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -913,6 +913,37 @@ module Bosh
               end
             end
           end
+
+          describe 'enable_ipv6' do
+            context 'when it is not set' do
+              it 'does not render into the config' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['enable_ipv6']).to be_nil
+              end
+            end
+
+            context 'when it is set to false' do
+              before do
+                merged_manifest_properties['cc']['enable_ipv6'] = false
+              end
+
+              it 'renders it as false' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['enable_ipv6']).to be(false)
+              end
+            end
+
+            context 'when it is set to true' do
+              before do
+                merged_manifest_properties['cc']['enable_ipv6'] = true
+              end
+
+              it 'renders it as true' do
+                template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+                expect(template_hash['enable_ipv6']).to be(true)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
* A short explanation of the proposed change:
Adds config for enabling ipv6
* An explanation of the use cases your change solves

* Links to any other associated PRs
CC: https://github.com/cloudfoundry/cloud_controller_ng/pull/4318
RFC: https://github.com/cloudfoundry/community/pull/1077

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
