### PR TITLE
Add validation of db encryption keys to cc_ng pre start migrations

### DIFF
--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -12,9 +12,9 @@ echo 'Running migrations and seeds'
 /var/vcap/jobs/cloud_controller_ng/bin/migrate_db
 /var/vcap/jobs/cloud_controller_ng/bin/seed_db
 echo 'Finished migrations and seeds'
-  <% if !p('cc.database_encryption.skip_validation') %>
-    /var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
-  <% end %>
+<% if !p('cc.database_encryption.skip_validation') %>
+/var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+<% end %>
 <% end %>
 
 <% if p('cc.experimental.use_yjit_compiler') %>

--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -12,9 +12,9 @@ echo 'Running migrations and seeds'
 /var/vcap/jobs/cloud_controller_ng/bin/migrate_db
 /var/vcap/jobs/cloud_controller_ng/bin/seed_db
 echo 'Finished migrations and seeds'
-<% end %>
-<% if !p('cc.database_encryption.skip_validation') %>
-  /var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+  <% if !p('cc.database_encryption.skip_validation') %>
+    /var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+  <% end %>
 <% end %>
 
 <% if p('cc.experimental.use_yjit_compiler') %>

--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -13,6 +13,9 @@ echo 'Running migrations and seeds'
 /var/vcap/jobs/cloud_controller_ng/bin/seed_db
 echo 'Finished migrations and seeds'
 <% end %>
+<% if !p('cc.database_encryption.skip_validation') %>
+  /var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+<% end %>
 
 <% if p('cc.experimental.use_yjit_compiler') %>
 export RUBYOPT='--yjit'


### PR DESCRIPTION

* A short explanation of the proposed change:
We want to compare key labels configured in cloud_controller_ng.yml with those used in the different database tables ("encryption_key_label" row) and when a key label is used but not configured, simply fail to start. This validation step is only performed when cc.database_encryption.skip_validation is not set to true.
* An explanation of the use cases your change solves
This change ensures that the Cloud Controller fails fast during startup if encryption keys referenced in the database are not properly configured. In environments where data encryption is enabled, having a mismatch between configured encryption keys and those in use can lead to runtime failures or silent decryption issues. 
* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
