### PR TITLE
Revert "Add draining for cc_uploader (#529)"

### DIFF
--- a/jobs/cc_uploader/monit
+++ b/jobs/cc_uploader/monit
@@ -2,5 +2,4 @@ check process cc_uploader
   with pidfile /var/vcap/sys/run/bpm/cc_uploader/cc_uploader.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cc_uploader"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cc_uploader"
-  depends on cloud_controller_ng
   group vcap

--- a/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
+++ b/jobs/cloud_controller_ng/templates/shutdown_drain.rb.erb
@@ -6,8 +6,6 @@ $LOAD_PATH.unshift('/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/l
 require 'cloud_controller/drain'
 
 @drain = VCAP::CloudController::Drain.new('/var/vcap/sys/log/cloud_controller_ng')
-
-@drain.shutdown_cc_uploader('/var/vcap/sys/run/bpm/cc_uploader/cc_uploader.pid')
 @drain.shutdown_nginx('/var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid', <%= p("cc.nginx_drain_timeout") %>)
 @drain.shutdown_cc('/var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid')
 @threads = []


### PR DESCRIPTION
This reverts commit 45d2a21fc5e4d71e3dcf971b006e5a6d2b2b94db.

This original commit introduces the requirement that cc_uploader is co-located on the same VM as the cloud_controller_ng job. While this is the case in cf-deployment, this is not the case for all deployments of CF (like the VMware one).

As this commit has broken our deployment, and its not easy for us simply to relocate the job, we propose we revert this and discuss options going forwards.

The cc_uploader originally was designed an independent process, typically processes that require to be co-located are within the same job. E.g. nginx, cloud_controller_ng and cloud_controller_local_worker.

Some options:
* Investigate a way to generically drain uploads from any source in nginx rather than specifically in cc_uploader.
    * Current timeout is [10 seconds](https://github.com/cloudfoundry/cloud_controller_ng/blob/5c4dac049bd28979284aeab1efa48c7075676131/lib/cloud_controller/drain.rb#L9)
* Find a way to sync draining between jobs without requiring co-location.
* Keep the co-location requirement for draining but behind a capi-property.

We can discuss options async or at the next office hours (14th May)

---

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
