### PR TITLE
Add logging and fix indentation 

### DIFF
--- a/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -8,14 +8,17 @@ wait_for_blobstore
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
 
 <% if spec.bootstrap && !p('cc.run_prestart_migrations') %>
-echo 'Running migrations and seeds'
-/var/vcap/jobs/cloud_controller_ng/bin/migrate_db
-/var/vcap/jobs/cloud_controller_ng/bin/seed_db
-echo 'Finished migrations and seeds'
-<% if !p('cc.database_encryption.skip_validation') %>
-/var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+  echo 'Running migrations and seeds'
+  /var/vcap/jobs/cloud_controller_ng/bin/migrate_db
+  /var/vcap/jobs/cloud_controller_ng/bin/seed_db
+  echo 'Finished migrations and seeds'
+  <% unless p('cc.database_encryption.skip_validation') %>
+    echo 'Validating encryption keys'
+    /var/vcap/jobs/cloud_controller_ng/bin/validate_encryption_keys
+    echo 'Finished validating encryption keys'
+  <% end %>
 <% end %>
-<% end %>
+
 
 <% if p('cc.experimental.use_yjit_compiler') %>
 export RUBYOPT='--yjit'


### PR DESCRIPTION

* A short explanation of the proposed change:
Add log output to cloud controller start script in case encryption key validation runs. Fix indentation of the lines so that lines get rendered into bin/cloud_controller_ng.
* An explanation of the use cases your change solves
Inform operators if validation did run. Encryption key validation gets rendered into /var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng start script.
* Links to any other associated PRs
#538
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
