### PR TITLE
Add properties for specifying an allowlist of Process users

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -208,6 +208,10 @@ properties:
     description: "The file descriptors made available to each app instance"
     default: 16384
 
+  cc.allowed_process_users:
+    default: ['vcap']
+    description: "Allow-list of users that a Process/Task may use"
+
   cc.locket.host:
     default: "locket.service.cf.internal"
     description: "Hostname of the Locket server"

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -133,6 +133,7 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
+allowed_process_users: <%= p("cc.allowed_process_users") %>
 
 deployment_updater:
   update_frequency_in_seconds: <%= p("deployment_updater.update_frequency_in_seconds") %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -422,6 +422,10 @@ properties:
     default: 2048
     description: "The maximum amount of disk a user can request"
 
+  cc.allowed_process_users:
+    default: ['vcap']
+    description: "Allow-list of users that a Process/Task may use"
+
   cc.newrelic.license_key:
     default: ~
     description: "The api key for NewRelic"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -72,6 +72,7 @@ maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 max_retained_deployments_per_app: <%= p("cc.max_retained_deployments_per_app") %>
 max_retained_builds_per_app: <%= p("cc.max_retained_builds_per_app") %>
 max_retained_revisions_per_app: <%= p("cc.max_retained_revisions_per_app") %>
+allowed_process_users: <%= p("cc.allowed_process_users") %>
 
 default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -844,6 +844,10 @@ properties:
     default: "2048M"
     description: "Maximum body size for nginx bits uploads"
 
+  cc.allowed_process_users:
+    default: ['vcap']
+    description: "Allow-list of users that a Process/Task may use"
+
   cc.default_app_log_rate_limit_in_bytes_per_second:
     default: -1
     description: "Default application log rate limit"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -128,6 +128,7 @@ cpu_weight_max_memory: <%= p("cc.cpu_weight_max_memory") %>
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
+allowed_process_users: <%= p("cc.allowed_process_users") %>
 
 default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -364,6 +364,10 @@ properties:
     default: 2048
     description: "The maximum amount of disk a user can request"
 
+  cc.allowed_process_users:
+    default: ['vcap']
+    description: "Allow-list of users that a Process/Task may use"
+
   cc.allow_app_ssh_access:
     default: true
     description: "Allow users to change the value of the app-level allow_ssh attribute"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -63,6 +63,7 @@ jobs:
 default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
+allowed_process_users: <%= p("cc.allowed_process_users") %>
 
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 


### PR DESCRIPTION
This PR introduces a new property to allow the platform operator to control what users a buildpack/cnb lifecycle app runs with.

See https://github.com/cloudfoundry/cloud_controller_ng/pull/4407 and https://github.com/cloudfoundry/cloud_controller_ng/issues/4372 for more details.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
