### PR TITLE
Increase nginx keepalive_timeout to 100s

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -971,7 +971,7 @@ properties:
 
   cc.server_keepalive_timeout:
     description: "Configure keep alive timeout for connections to cloud controller. This is a temporary field used for testing."
-    default: 75
+    default: 100
 
   cc.jobs.local.number_of_workers:
     default: 2


### PR DESCRIPTION
- keepalive_timeout of server should be larger than value of client
- gorouter (client of CC nginx) has hardcoded 90s https://github.com/cloudfoundry/gorouter/blob/a602bb6a624308630305f7f61689fddd21347dcb/proxy/proxy.go#L87
- related: https://github.com/cloudfoundry/routing-release/issues/240
- did not change the value reported by the Keep-Alive header (20s) because CC has no control of gorouter keepalive timeouts (or whatever additional component like haproxy, LB stands between CC and user)

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
