### PR TITLE
Configure new status health check

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1327,6 +1327,10 @@ properties:
   cc.enable_ipv6:
     description: "Enable IPv6 support in Cloud Controller."
 
+  cc.use_status_check:
+    description: "Let monit use the /internal/v4/status endpoint to determine if the Cloud Controller is healthy. Only if the status endpoint returns unhealthy or the status has not been OK for 600 seconds, it will trigger a restart. This only takes effect when Puma is used."
+    default: false
+
 # deprecated configuration
 
   cc.experimental.use_puma_webserver:

--- a/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
+++ b/jobs/cloud_controller_ng/templates/ccng_monit_http_healthcheck.sh.erb
@@ -25,14 +25,71 @@ function log_failure {
   echo "$(date --rfc-3339=ns) :: Healthcheck failed consistently, restarting CC"
 }
 
+echo $(date --rfc-3339=ns) 'Will restart CC over on repeated failures'
+trap log_failure EXIT
+
+<%
+def thin_webserver_enabled?
+  if_p('cc.experimental.use_puma_webserver') do |prop|
+    return !prop
+  end
+
+  p('cc.temporary_enable_deprecated_thin_webserver')
+end
+-%>
+
+<% if !thin_webserver_enabled? && p('cc.use_status_check') %>
+# Use /internal/v4/status readiness endpoint
+HOST=<%= p('cc.nginx.ip').empty? ? discover_external_ip : p('cc.nginx.ip') %>
+PORT=9021
+PROTOCOL="http"
+READINESS_URL="${PROTOCOL}://${HOST}:${PORT}/internal/v4/status"
+
+last_ok_response=$(date +%s)
+
+while true; do
+  set +e
+  readiness_code=$(curl --fail -sS -o /dev/null -w "%{http_code}" --max-time 2 -A "ccng_monit_http_healthcheck" "${READINESS_URL}")
+  set -e
+  status=$?
+
+  now=$(date +%s)
+  elapsed=$((now - last_ok_response))
+  if [[ "$readiness_code" == "200" ]]; then
+    # Reset timer on success
+    last_ok_response=$now
+    sleep 10
+    continue
+  fi
+
+  if [[ $status == 7 ]]; then
+    # Connection refused/unreachable, do not exit
+    sleep 10
+    continue
+  fi
+
+  if [[ "$readiness_code" == "503" ]]; then
+    echo "$(date --rfc-3339=ns) ccng_monit_http_healthcheck: readiness endpoint returned 503 (unhealthy), exiting to trigger restart"
+    exit $status
+  elif [[ "$readiness_code" == "429" ]]; then
+    echo "$(date --rfc-3339=ns) ccng_monit_http_healthcheck: readiness endpoint returned 429 (busy), not restarting"
+    # Do not exit, just log and continue
+  else
+    echo "$(date --rfc-3339=ns) ccng_monit_http_healthcheck: readiness endpoint returned unexpected HTTP code $readiness_code"
+  fi
+
+  # Killswitch: exit with non-zero if no 200 within 10 minutes
+  if [[ $elapsed -ge 600 ]]; then
+    echo "$(date --rfc-3339=ns) ccng_monit_http_healthcheck: readiness endpoint did not return 200 for $elapsed seconds, exiting with error"
+    exit 2
+  fi
+  sleep 10
+done
+<% else %>
 HOST=<%= p('cc.nginx.ip').empty? ? discover_external_ip : p('cc.nginx.ip') %>
 PORT=<%= p("cc.public_tls.port") %>
 PROTOCOL="https"
-URL="https://${HOST}:${PORT}/healthz"
-
-echo $(date --rfc-3339=ns) 'Will restart CC over on repeated failures'
-
-trap log_failure EXIT
+URL="${PROTOCOL}://${HOST}:${PORT}/healthz"
 
 # If we fail to curl the healthz endpoint 5 times (can be changed with cc.ccng_monit_http_healthcheck_retries) with
 # a delay of 10 seconds between each retry, exit in order to trigger a restart of cloud controller through monit.
@@ -58,3 +115,4 @@ while true; do
   fi
   sleep 10
 done
+<% end %>

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -199,4 +199,17 @@ end
     include nginx_external_endpoints.conf;
   }
   <% end %>
+
+  <% if !thin_webserver_enabled? && p('cc.use_status_check') %>
+  # This block handles the /internal/v4/status endpoint for health checks, which is called by ccng_monit_http_healthcheck.
+  server {
+    listen 9021;
+    server_name _;
+    server_name_in_redirect off;
+
+    location /internal/v4/status {
+      proxy_pass http://cloud_controller_metrics;
+    }
+  }
+  <% end %>
 }

--- a/spec/cloud_controller_ng/healthcheck_spec.rb
+++ b/spec/cloud_controller_ng/healthcheck_spec.rb
@@ -20,12 +20,31 @@ module Bosh
             expect(rendered_file).to include('--retry 5')
           end
 
+          it 'uses the healthz endpoint' do
+            rendered_file = template.render({}, consumes: {})
+            expect(rendered_file).to include('/healthz')
+          end
+
           context 'when custom values are provided' do
             it 'renders the provided values' do
               rendered_file = template.render({ 'cc' => { 'ccng_monit_http_healthcheck_timeout_per_retry' => 30,
                                                           'ccng_monit_http_healthcheck_retries' => 2 } }, consumes: {})
               expect(rendered_file).to include('--max-time 30')
               expect(rendered_file).to include('--retry 2')
+            end
+          end
+
+          context 'when "use_status_check" is set to true' do
+            it 'uses the /v4/internal/status endpoint' do
+              rendered_file = template.render({ 'cc' => { 'use_status_check' => true } }, consumes: {})
+              expect(rendered_file).to include('/internal/v4/status')
+            end
+
+            context 'when Thin is used' do
+              it 'uses the healthz endpoint' do
+                rendered_file = template.render({ 'cc' => { 'use_status_check' => true, 'webserver' => 'thin' } }, consumes: {})
+                expect(rendered_file).not_to include('/healthz')
+              end
             end
           end
         end

--- a/spec/cloud_controller_ng/nginx_spec.rb
+++ b/spec/cloud_controller_ng/nginx_spec.rb
@@ -113,6 +113,28 @@ module Bosh
               end
             end
           end
+
+          describe 'status endpoint' do
+            it 'does not expose the /internal/v4/status endpoint' do
+              expect(@rendered_file).not_to include('/internal/v4/status')
+            end
+
+            context 'when use_status_check is true' do
+              let(:manifest_properties) { { 'cc' => { 'use_status_check' => true } } }
+
+              it 'exposes the /internal/v4/status endpoint' do
+                expect(@rendered_file).to include('location /internal/v4/status')
+              end
+
+              context 'when Thin is used' do
+                let(:manifest_properties) { super().merge('cc' => super()['cc'].merge('temporary_enable_deprecated_thin_webserver' => true)) }
+
+                it 'does not expose the /internal/v4/status endpoint' do
+                  expect(@rendered_file).not_to include('location /internal/v4/status')
+                end
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
### A short explanation of the proposed change:
Configure monit to use the new /internal/v4/status endpoint to determine whether CC is healthy and trigger restarts only when it returns unhealthy or 10 minutes have passed since the last OK was reported.

### An explanation of the use cases your change solves
This change prevents restarts of CC, even it is still healthy and working off peak loads.

### Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4441
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
