### PR TITLE
Add property to allow the use of the 'root' user for docker Apps

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -212,6 +212,10 @@ properties:
     default: []
     description: "Allow-list of users that a Process/Task may use in addition to 'vcap'. The 'vcap' user is always permitted."
 
+  cc.allow_process_root_user:
+    default: true
+    description: "Whether to allow the use of the 'root' user for a Process/Task of a docker lifecycle App. When false, uses 'vcap' user instead of 'root' by default."
+
   cc.locket.host:
     default: "locket.service.cf.internal"
     description: "Hostname of the Locket server"

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -134,6 +134,7 @@ default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 additional_allowed_process_users: <%= p("cc.additional_allowed_process_users") %>
+allow_process_root_user: <%= p("cc.allow_process_root_user") %>
 
 deployment_updater:
   update_frequency_in_seconds: <%= p("deployment_updater.update_frequency_in_seconds") %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -426,6 +426,10 @@ properties:
     default: []
     description: "Allow-list of users that a Process/Task may use in addition to 'vcap'. The 'vcap' user is always permitted."
 
+  cc.allow_process_root_user:
+    default: true
+    description: "Whether to allow the use of the 'root' user for a Process/Task of a docker lifecycle App. When false, uses 'vcap' user instead of 'root' by default."
+
   cc.newrelic.license_key:
     default: ~
     description: "The api key for NewRelic"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -73,6 +73,7 @@ max_retained_deployments_per_app: <%= p("cc.max_retained_deployments_per_app") %
 max_retained_builds_per_app: <%= p("cc.max_retained_builds_per_app") %>
 max_retained_revisions_per_app: <%= p("cc.max_retained_revisions_per_app") %>
 additional_allowed_process_users: <%= p("cc.additional_allowed_process_users") %>
+allow_process_root_user: <%= p("cc.allow_process_root_user") %>
 
 default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -848,6 +848,10 @@ properties:
     default: []
     description: "Allow-list of users that a Process/Task may use in addition to 'vcap'. The 'vcap' user is always permitted."
 
+  cc.allow_process_root_user:
+    default: true
+    description: "Whether to allow the use of the 'root' user for a Process/Task of a docker lifecycle App. When false, uses 'vcap' user instead of 'root' by default."
+
   cc.default_app_log_rate_limit_in_bytes_per_second:
     default: -1
     description: "Default application log rate limit"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -129,6 +129,7 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 additional_allowed_process_users: <%= p("cc.additional_allowed_process_users") %>
+allow_process_root_user: <%= p("cc.allow_process_root_user") %>
 
 default_app_log_rate_limit_in_bytes_per_second: <%= p("cc.default_app_log_rate_limit_in_bytes_per_second") %>
 

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -368,6 +368,10 @@ properties:
     default: []
     description: "Allow-list of users that a Process/Task may use in addition to 'vcap'. The 'vcap' user is always permitted."
 
+  cc.allow_process_root_user:
+    default: true
+    description: "Whether to allow the use of the 'root' user for a Process/Task of a docker lifecycle App. When false, uses 'vcap' user instead of 'root' by default."
+
   cc.allow_app_ssh_access:
     default: true
     description: "Allow users to change the value of the app-level allow_ssh attribute"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -64,6 +64,7 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 additional_allowed_process_users: <%= p("cc.additional_allowed_process_users") %>
+allow_process_root_user: <%= p("cc.allow_process_root_user") %>
 
 instance_file_descriptor_limit: <%= p("cc.instance_file_descriptor_limit") %>
 


### PR DESCRIPTION
### Background
Associated bosh release configuration for https://github.com/cloudfoundry/cloud_controller_ng/pull/4452

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
