### PR TITLE
Add cc uploader configurable drain timeout

### DIFF
--- a/jobs/cc_uploader/spec
+++ b/jobs/cc_uploader/spec
@@ -14,6 +14,7 @@ templates:
   cc_uploader_server.crt.erb: config/certs/cc_uploader/server.crt
   cc_uploader_server.key.erb: config/certs/cc_uploader/server.key
   pre-start.erb: bin/pre-start
+  drain.sh.erb: bin/drain
 
 packages:
   - capi_utils
@@ -75,3 +76,8 @@ properties:
     description: "PEM-encoded certificate for secure, mutually authenticated TLS communication"
   capi.cc_uploader.mutual_tls.server_key:
     description: "PEM-encoded key for secure, mutually authenticated TLS communication"
+
+  capi.cc_uploader.cc_uploader_drain_timeout_in_minutes:
+    description: Maximum time to wait for in‐flight uploads to finish before forcing shutdown
+    type: time
+    default: 15m

--- a/jobs/cc_uploader/templates/bpm.yml.erb
+++ b/jobs/cc_uploader/templates/bpm.yml.erb
@@ -4,5 +4,6 @@ processes:
   executable: /var/vcap/packages/cc_uploader/bin/cc-uploader
   args:
     - --configPath=/var/vcap/jobs/cc_uploader/config/cc_uploader_config.json
+    - --shutdownTimeoutInMinutes=<%= p("capi.cc_uploader.cc_uploader_drain_timeout_in_minutes") %>
   limits:
     open_files: 100000

--- a/jobs/cc_uploader/templates/drain.sh.erb
+++ b/jobs/cc_uploader/templates/drain.sh.erb
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+LOG_FILE="/var/vcap/sys/log/cc_uploader/drain.log"
+PID_FILE="/var/vcap/sys/run/bpm/cc_uploader/cc_uploader.pid"
+
+TIMEOUT_MINUTES="<%= p("capi.cc_uploader.cc_uploader_drain_timeout_in_minutes") %>"
+
+TIMEOUT_MINUTES="${TIMEOUT_MINUTES%m}"
+TIMEOUT_MINUTES="${TIMEOUT_MINUTES:-15}"
+
+DRAIN_TIMEOUT=$(( TIMEOUT_MINUTES * 60 ))
+START_TS=$(date +%s)
+
+echo "$(date): cc_uploader drain starting (timeout ${DRAIN_TIMEOUT}s)" >> "$LOG_FILE"
+
+if [ -f "$PID_FILE" ]; then
+  kill -TERM "$(cat "$PID_FILE")"
+  while kill -0 "$(cat "$PID_FILE")" >/dev/null 2>&1; do
+    NOW_TS=$(date +%s)
+    ELAPSED=$(( NOW_TS - START_TS ))
+    if [ "$ELAPSED" -ge "$DRAIN_TIMEOUT" ]; then
+      echo "$(date): drain timeout reached after ${DRAIN_TIMEOUT}s, forcing exit" >> "$LOG_FILE"
+      break
+    fi
+    echo "$(date): waiting for cc_uploader (elapsed ${ELAPSED}s)" >> "$LOG_FILE"
+    sleep 1
+  done
+fi
+
+echo "$(date): drain complete, returning 0 to BOSH" >> "$LOG_FILE"
+echo 0
+exit 0
+


### PR DESCRIPTION
- Add `capi.cc_uploader.cc_uploader_drain_timeout_in_minutes` (type: time, default: 15m) to job spec
- Inject `--shutdownTimeoutInMinutes=<%= p("capi.cc_uploader.cc_uploader_drain_timeout_in_minutes") %>` into `bpm.yml.erb`
- Update `drain.sh.erb` to read the same property, apply the timeout when waiting for PID exit
- Retain 15-minute fallback in the script for robustness against missing property values

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Allow operators to tune how long the CC-Uploader waits for in-flight uploads to finish during drain by introducing a new BOSH property (capi.cc_uploader.cc_uploader_drain_timeout_in_minutes) with a sane default of 15 minutes, wiring it through both the BPM startup flags and the drain script.
* An explanation of the use cases your change solves
Let operators configure how long CC-Uploader waits (with a default of 15 minutes) during VM shutdown so active uploads complete gracefully.
* Links to any other associated PRs
https://github.com/cloudfoundry/cc-uploader/pull/245
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [] I have run CF Acceptance Tests on bosh lite
