### PR TITLE
feat: Platform Engineer can configure CF feature flags via bosh deplo…

### DIFF
--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -278,3 +278,7 @@ cpu_weight_max_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_ma
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>
 
 app_log_revision: <%= link("cloud_controller_internal").p("cc.app_log_revision") %>
+
+<% link("cloud_controller_internal").if_p("cc.feature_flag_overrides") do |feature_flag_overrides| %>
+feature_flag_overrides: <%= feature_flag_overrides.to_json %>
+<% end %>

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -367,3 +367,7 @@ cpu_weight_max_memory: <%= link("cloud_controller_internal").p("cc.cpu_weight_ma
 custom_metric_tag_prefix_list: <%= link("cloud_controller_internal").p("cc.custom_metric_tag_prefix_list") %>
 
 app_log_revision: <%= link("cloud_controller_internal").p("cc.app_log_revision") %>
+
+<% link("cloud_controller_internal").if_p("cc.feature_flag_overrides") do |feature_flag_overrides| %>
+feature_flag_overrides: <%= feature_flag_overrides.to_json %>
+<% end %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -233,6 +233,7 @@ provides:
   - cc.deprecated_stacks
   - cc.temporary_enable_deprecated_thin_webserver
   - cc.custom_root_links
+  - cc.feature_flag_overrides
   
 consumes:
 - name: database
@@ -1330,6 +1331,10 @@ properties:
   cc.use_status_check:
     description: "Let monit use the /internal/v4/status endpoint to determine if the Cloud Controller is healthy. Only if the status endpoint returns unhealthy or the status has not been OK for 600 seconds, it will trigger a restart. This only takes effect when Puma is used."
     default: false
+
+  cc.feature_flag_overrides:
+    description: "Feature flag key-value pairs to override default feature flags"
+    default: {}
 
 # deprecated configuration
 

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -591,3 +591,7 @@ allow_user_creation_by_org_manager: <%= allow_user_creation %>
 <% if_p("cc.enable_ipv6") do |enable_ipv6| %>
 enable_ipv6: <%= enable_ipv6 %>
 <% end %>
+
+<% if_p("cc.feature_flag_overrides") do |feature_flag_overrides| %>
+feature_flag_overrides: <%= feature_flag_overrides.to_json %>
+<% end %>

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -367,3 +367,7 @@ prometheus_port: <%= p("cc.prometheus_port") %>
 default_app_lifecycle: <%= link("cloud_controller_internal").p("cc.default_app_lifecycle") %>
 directories:
   tmpdir: <%= p("cc.directories.tmpdir") %>
+
+<% link("cloud_controller_internal").if_p("cc.feature_flag_overrides") do |feature_flag_overrides| %>
+feature_flag_overrides: <%= feature_flag_overrides.to_json %>
+<% end %>


### PR DESCRIPTION
…yment

- Added a new property to override default feature flags.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
  The objective: Platform engineer can override feature flags in the capi release bosh deployment manifest.

* An explanation of the use cases your change solves
  See the above.

* Links to any other associated PRs
  https://github.com/cloudfoundry/cloud_controller_ng/pull/4523

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run CF Acceptance Tests on bosh lite
