### PR TITLE
Implement RFC-0027: Add max_route_options_size BOSH property

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -148,6 +148,7 @@ provides:
   - cc.default_stack
   - cc.default_app_lifecycle
   - cc.disable_private_domain_cross_space_context_path_route_sharing
+  - cc.max_route_options_size
   - cc.droplets.blobstore_provider
   - cc.droplets.blobstore_type
   - cc.droplets.cdn.key_pair_id
@@ -1138,6 +1139,10 @@ properties:
   cc.disable_private_domain_cross_space_context_path_route_sharing:
     description: "Disallow route collisions over shared private domains when created in different spaces"
     default: false
+
+  cc.max_route_options_size:
+    description: "Maximum size in bytes for the serialized route options JSON. Routes with options exceeding this limit will be rejected with HTTP 422 Unprocessable Entity. See RFC-0027 for details on tuning this alongside route emit interval."
+    default: 1024
 
   cc.core_file_pattern:
     description: "Filename template for core dump files. Use an empty string if you don't want core files saved."

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -86,6 +86,7 @@ custom_root_links.to_json
 
 reserved_private_domains: <%= p("cc.reserved_private_domains", nil) %>
 disable_private_domain_cross_space_context_path_route_sharing: <%= p("cc.disable_private_domain_cross_space_context_path_route_sharing", false) %>
+max_route_options_size: <%= p("cc.max_route_options_size") %>
 
 jobs:
   enable_dynamic_job_priorities: <%= p("cc.jobs.enable_dynamic_job_priorities") %>

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -351,6 +351,7 @@ system_domain: <%= p("system_domain") %>
 system_hostnames: <%= link("cloud_controller_internal").p("cc.system_hostnames") %>
 
 disable_private_domain_cross_space_context_path_route_sharing: <%= link("cloud_controller_internal").p("cc.disable_private_domain_cross_space_context_path_route_sharing") %>
+max_route_options_size: <%= link("cloud_controller_internal").p("cc.max_route_options_size") %>
 
 max_service_credential_bindings_per_app_service_instance: <%= link("cloud_controller_internal").p("cc.max_service_credential_bindings_per_app_service_instance") %>
 

--- a/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
+++ b/spec/cloud_controller_worker/cloud_controller_worker_spec.rb
@@ -74,6 +74,7 @@ module Bosh
               },
               'max_labels_per_resource' => true,
               'max_annotations_per_resource' => 'yus',
+              'max_route_options_size' => 1024,
               'disable_private_domain_cross_space_context_path_route_sharing' => false,
               'cpu_weight_min_memory' => 128,
               'cpu_weight_max_memory' => 8192,


### PR DESCRIPTION
## Summary

Adds the `cc.max_route_options_size` BOSH property to support the route options size limit implemented in [cloudfoundry/cloud_controller_ng#4934](https://github.com/cloudfoundry/cloud_controller_ng/pull/4934). The property is propagated to the worker job via the `cloud_controller_internal` BOSH link, consistent with how other validation limits (e.g. `max_labels_per_resource`, `max_annotations_per_resource`) are shared across CC components.

## Changes

- **`jobs/cloud_controller_ng/spec`**: Added `cc.max_route_options_size` property (default: 1024) and exposed it in the `cloud_controller_internal` link's properties list
- **`jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb`**: Maps the property to the CC config
- **`jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb`**: Consumes the property via the `cloud_controller_internal` link

## Property

| Name | Default | Description |
|------|---------|-------------|
| `cc.max_route_options_size` | `1024` | Maximum size in bytes for serialized route options JSON. Requests exceeding this limit are rejected with HTTP 422. |

## Related

- RFC amendment: https://github.com/cloudfoundry/community/pull/1447
- Companion cloud_controller_ng PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/4934