### PR TITLE
Remove unused ruby-3.2 package

### DIFF
--- a/packages/ruby-3.2/spec.lock
+++ b/packages/ruby-3.2/spec.lock
@@ -1,2 +1,0 @@
-name: ruby-3.2
-fingerprint: 65552e74be30d05a0338da3d4ff806251ab1cded8c2c81d73e5c383981eef2b3


### PR DESCRIPTION
All jobs and packages now use ruby-3.3 exclusively.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
