### PR TITLE
initial resolute raccoon support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,9 @@ jemalloc/jemalloc-5.3.0.tar.bz2:
   size: 736023
   object_id: 1ded0db4-5ba5-4b71-58d0-3b638b98f15b
   sha: sha256:2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
-mariadb_connector_c/mariadb-connector-c-3.3.5-src.tar.gz:
-  size: 1392609
-  object_id: ca059f02-93a8-491b-74cb-44dcc0a59bbc
-  sha: sha256:ca72eb26f6db2befa77e48ff966f71bcd3cb44b33bd8bbb810b65e6d011c1e5c
+mariadb_connector_c/mariadb-connector-c-3.4.8-src.tar.gz:
+  size: 1380411
+  sha: sha256:156aed3b49f857d0ac74fb76f1982968bcbfd8382da3f5b6ae71f616729920d7
 nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: a7207ad8-8660-4e0d-72a1-7fdd605e131d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,9 @@ jemalloc/jemalloc-5.3.1.tar.bz2:
   size: 920181
   object_id: 70c25209-2f7b-43c5-48ed-68dd155af980
   sha: sha256:3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92
-mariadb_connector_c/mariadb-connector-c-3.3.5-src.tar.gz:
-  size: 1392609
-  object_id: ca059f02-93a8-491b-74cb-44dcc0a59bbc
-  sha: sha256:ca72eb26f6db2befa77e48ff966f71bcd3cb44b33bd8bbb810b65e6d011c1e5c
+mariadb_connector_c/mariadb-connector-c-3.4.8-src.tar.gz:
+  size: 1380411
+  sha: sha256:156aed3b49f857d0ac74fb76f1982968bcbfd8382da3f5b6ae71f616729920d7
 nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: a7207ad8-8660-4e0d-72a1-7fdd605e131d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -8,6 +8,7 @@ jemalloc/jemalloc-5.3.1.tar.bz2:
   sha: sha256:3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92
 mariadb_connector_c/mariadb-connector-c-3.4.8-src.tar.gz:
   size: 1380411
+  object_id: 652faffa-0c2f-45f1-6b2e-84312cdc7f21
   sha: sha256:156aed3b49f857d0ac74fb76f1982968bcbfd8382da3f5b6ae71f616729920d7
 nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054

--- a/packages/mariadb_connector_c/packaging
+++ b/packages/mariadb_connector_c/packaging
@@ -1,13 +1,13 @@
 set -e -x
 
-VERSION=3.3.5
+VERSION=3.4.8
 
 tar xzf mariadb_connector_c/mariadb-connector-c-${VERSION}-src.tar.gz
 
 pushd mariadb-connector-c-${VERSION}-src > /dev/null
 	mkdir bld
 	cd bld
-	cmake .. -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET}
+	cmake .. -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
 	make
 	make install
 popd > /dev/null

--- a/packages/mariadb_connector_c/spec
+++ b/packages/mariadb_connector_c/spec
@@ -1,5 +1,5 @@
 ---
 name: mariadb_connector_c
 files:
-- mariadb_connector_c/mariadb-connector-c-3.3.5-src.tar.gz
+- mariadb_connector_c/mariadb-connector-c-3.4.8-src.tar.gz
 - mariadb-customization/*


### PR DESCRIPTION
These changes enable compiling pxc-release on Resolute Raccoon, the new Ubuntu LTS version. These changes were made during the production of the initial alpha stemcell to validate that cf-deployment can be deployed using the new stemcell.

This PR does introduce some new blobs that will need to be synced to the blobstore.

* Links to any other associated PRs
https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/497

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite

# AI Slop Explanation of Changes

## Overview

Resolute Raccoon ships GCC 14/15 and CMake 4.2. Only one package in
capi-release required changes: `mariadb_connector_c`.

---

## Changed packages

### 1. `mariadb_connector_c` — bumped from 3.3.5 to 3.4.8

**Problem:** mariadb-connector-c 3.3.5 failed to compile under GCC 14 with
multiple warnings promoted to errors. The key issues were:

- Implicit function declarations (now errors in C23/GCC 14 by default)
- Deprecated OpenSSL API usage producing `-Werror` failures
- Incompatible pointer type warnings treated as errors

The 3.3.x series is no longer maintained upstream and does not have patches
for modern compiler compatibility.

**Fix (two parts):**

1. **Bumped the blob** from `mariadb-connector-c-3.3.5-src.tar.gz` to
   `mariadb-connector-c-3.4.8-src.tar.gz`. The 3.4.x series has upstream
   fixes for GCC 14 and OpenSSL 3.x compatibility.

2. **Added `-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF`** to the cmake invocation.
   Even 3.4.8 produces some warnings under GCC 14 that the project's CMake
   configuration promotes to errors. This flag disables that behavior.

**Jammy compat:** mariadb-connector-c 3.4.8 is API-compatible with 3.3.5.
The `-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF` flag is a no-op on versions of
CMake that don't support it (< 3.24), so this is safe on Jammy.

---

## Things to watch for in the future

- **mariadb-connector-c upstream.** The 3.4.x series is actively maintained
  and should track well with future compiler updates. If a future stemcell
  bumps GCC again, check whether `-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF` is
  still needed or can be removed.

- **OpenSSL 3.x deprecations.** The connector uses some OpenSSL APIs that
  are deprecated in 3.x. They still work but may be removed in a future
  OpenSSL release. A future bump of mariadb-connector-c should resolve this.

