### PR TITLE
New configs for the grpc loggregator client

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -426,13 +426,6 @@ properties:
     description: "The internal URL used by UAA"
     default: "uaa.service.cf.internal"
 
-  metron_endpoint.host:
-    description: "The host used to emit messages to the Metron agent"
-    default: "127.0.0.1"
-  metron_endpoint.port:
-    description: "The port used to emit messages to the Metron agent"
-    default: 3457
-
   cc.db_encryption_key:
     default: ""
     description: "key for encrypting sensitive values in the CC database"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -142,9 +142,6 @@ logging:
 
 log_audit_events: <%= p("cc.log_audit_events") %>
 
-loggregator:
-  router: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
-
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
 <% db_role = p("ccdb.roles").find { |role| role["tag"] == "admin" } %>
 <%

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1313,6 +1313,9 @@ properties:
     description: "PEM-encoded client certificate for mTLS communication with Loggregator"
   cc.loggregator_tls.private_key:
     description: "PEM-encoded private key for mTLS communication with Loggregator"
+  cc.loggregator_tls.subject_name:
+    description: "The host name the client will accept on the server certificate when communicating with Loggregator via mTLS"
+    default: "metron"
 
   credhub_api.hostname:
     description: "Hostname used to resolve the address of CredHub"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -68,7 +68,9 @@ templates:
   credhub_ca.crt.erb: config/certs/credhub_ca.crt
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
   cloud_controller_local_worker_override.yml.erb: config/cloud_controller_local_worker_override.yml
-
+  loggregator_tls.crt.erb: config/certs/loggregator_tls.crt
+  loggregator_tls.key.erb: config/certs/loggregator_tls.key
+  loggregator_tls_ca.crt.erb: config/certs/loggregator_tls_ca.crt
 packages:
   - storage-cli
   - capi_utils
@@ -819,7 +821,7 @@ properties:
     default: "127.0.0.1"
   metron_endpoint.port:
     description: "The port used to emit messages to the Metron agent"
-    default: 3457
+    default: 3458
 
   doppler.use_ssl:
     description: "Whether to use ssl for the doppler_logging_endpoint listed at /v2/info"
@@ -1304,10 +1306,13 @@ properties:
   cc.logcache_tls.subject_name:
     description: "The host name the client will accept on the server certificate when communicating with Log Cache via mTLS"
     default: "log_cache"
-
-  cc.loggregator.internal_url:
-    description: "Internal URL used to communicate with traffic_controller"
-    default: "http://loggregator-trafficcontroller.service.cf.internal:8081"
+  
+  cc.loggregator_tls.ca_cert:
+    description: "PEM-encoded CA certificate for mTLS communication with Loggregator"
+  cc.loggregator_tls.certificate:
+    description: "PEM-encoded client certificate for mTLS communication with Loggregator"
+  cc.loggregator_tls.private_key:
+    description: "PEM-encoded private key for mTLS communication with Loggregator"
 
   credhub_api.hostname:
     description: "Hostname used to resolve the address of CredHub"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -185,8 +185,10 @@ logcache_tls:
   subject_name: <%= p("cc.logcache_tls.subject_name") %>
 
 loggregator:
-  router: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
-  internal_url: <%= p("cc.loggregator.internal_url") %>
+  endpoint: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
+  key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls.key
+  cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls.crt
+  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls_ca.crt
 
 log_stream:
   url: https://log-stream.<%= p("system_domain") %>

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -186,6 +186,7 @@ logcache_tls:
 
 loggregator:
   endpoint: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
+  subject_name: <%= p("cc.loggregator_tls.subject_name") %>
   key_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls.key
   cert_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls.crt
   ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/loggregator_tls_ca.crt

--- a/jobs/cloud_controller_ng/templates/loggregator_tls.crt.erb
+++ b/jobs/cloud_controller_ng/templates/loggregator_tls.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.certificate', '') %>

--- a/jobs/cloud_controller_ng/templates/loggregator_tls.key.erb
+++ b/jobs/cloud_controller_ng/templates/loggregator_tls.key.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.private_key', '') %>

--- a/jobs/cloud_controller_ng/templates/loggregator_tls_ca.crt.erb
+++ b/jobs/cloud_controller_ng/templates/loggregator_tls_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.ca_cert', '') %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -620,6 +620,9 @@ properties:
     description: "PEM-encoded client certificate for mTLS communication with Loggregator"
   cc.loggregator_tls.private_key:
     description: "PEM-encoded private key for mTLS communication with Loggregator"
+  cc.loggregator_tls.subject_name:
+    description: "The host name the client will accept on the server certificate when communicating with Loggregator via mTLS"
+    default: "metron"
 
   cc.perform_blob_cleanup:
     description: "Whether or not to perform the blob cleanup job"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -29,6 +29,9 @@ templates:
   mutual_tls_ca.crt.erb: config/certs/mutual_tls_ca.crt
   mutual_tls.crt.erb: config/certs/mutual_tls.crt
   mutual_tls.key.erb: config/certs/mutual_tls.key
+  loggregator_tls_ca.crt.erb: config/certs/loggregator_tls_ca.crt
+  loggregator_tls.crt.erb: config/certs/loggregator_tls.crt
+  loggregator_tls.key.erb: config/certs/loggregator_tls.key
   uaa_ca.crt.erb: config/certs/uaa_ca.crt
   db_ca.crt.erb: config/certs/db_ca.crt
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
@@ -423,7 +426,7 @@ properties:
     default: "127.0.0.1"
   metron_endpoint.port:
     description: "The port used to emit messages to the Metron agent"
-    default: 3457
+    default: 3458
 
   cc.broker_client_timeout_seconds:
     default: 60
@@ -611,9 +614,12 @@ properties:
     description: "Maximum PID limit for containerized work running user-provided code"
     default: 1024
 
-  cc.loggregator.internal_url:
-    description: "Internal URL used to communicate with traffic_controller"
-    default: "http://loggregator-trafficcontroller.service.cf.internal:8081"
+  cc.loggregator_tls.ca_cert:
+    description: "PEM-encoded CA certificate for mTLS communication with Loggregator"
+  cc.loggregator_tls.certificate:
+    description: "PEM-encoded client certificate for mTLS communication with Loggregator"
+  cc.loggregator_tls.private_key:
+    description: "PEM-encoded private key for mTLS communication with Loggregator"
 
   cc.perform_blob_cleanup:
     description: "Whether or not to perform the blob cleanup job"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -95,6 +95,7 @@ log_audit_events: <%= p("cc.log_audit_events") %>
 
 loggregator:
   endpoint: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
+  subject_name: <%= p("cc.loggregator_tls.subject_name") %>
   key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls.key
   cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls.crt
   ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls_ca.crt

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -94,7 +94,10 @@ logging:
 log_audit_events: <%= p("cc.log_audit_events") %>
 
 loggregator:
-  router: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
+  endpoint: <%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.port") %>
+  key_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls.key
+  cert_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls.crt
+  ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/loggregator_tls_ca.crt
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
 <% db_role = p("ccdb.roles").find { |role| role["tag"] == "admin" } %>

--- a/jobs/cloud_controller_worker/templates/loggregator_tls.crt.erb
+++ b/jobs/cloud_controller_worker/templates/loggregator_tls.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.certificate', '') %>

--- a/jobs/cloud_controller_worker/templates/loggregator_tls.key.erb
+++ b/jobs/cloud_controller_worker/templates/loggregator_tls.key.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.private_key', '') %>

--- a/jobs/cloud_controller_worker/templates/loggregator_tls_ca.crt.erb
+++ b/jobs/cloud_controller_worker/templates/loggregator_tls_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.loggregator_tls.ca_cert', '') %>


### PR DESCRIPTION
Switch CC jobs from UDP-based Loggregator communication to mTLS via the Loggregator Forwarder Agent.

Changes:
  - Add **loggregator_tls cert/key/CA** templates to **cloud_controller_ng** and **cloud_controller_worker** jobs
- Declare **cc.loggregator_tls.{ca_cert,certificate,private_key}** properties in both specs
- Update default **metron_endpoint.port**  from **3457** to **3458** (Forwarder Agent gRPC port)
- Remove unused loggregator: config from **cloud_controller_clock**

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/5043
https://github.com/cloudfoundry/cf-deployment/pull/1327
https://github.com/cloudfoundry/cf-acceptance-tests/pull/1920

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
