### PR TITLE
Remove unused health check script

### DIFF
--- a/jobs/blobstore/spec
+++ b/jobs/blobstore/spec
@@ -5,7 +5,6 @@ templates:
   bpm.yml.erb:        config/bpm.yml
   bin/blobstore_nginx.erb:  bin/blobstore_nginx
 
-  dns_health_check.erb: bin/dns_health_check
   nginx.conf.erb:       config/nginx.conf
   blobstore.conf.erb:   config/sites/blobstore.conf
   mime.types:           config/mime.types

--- a/jobs/blobstore/templates/dns_health_check.erb
+++ b/jobs/blobstore/templates/dns_health_check.erb
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-nc -z 127.0.0.1 <%= p("blobstore.port") %>
-
-# http://www.consul.io/docs/agent/checks.html
-if [ $? -ne 0 ]; then
-  exit 2 # Exit higher than 1 to ensure service is registered as 'critical'
-fi

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -20,7 +20,6 @@ templates:
   cloud_controller_api_health_check.erb: bin/cloud_controller_ng_health_check
   ccng_monit_http_healthcheck.sh.erb: bin/ccng_monit_http_healthcheck
   console.erb: bin/console
-  dns_health_check.erb: bin/dns_health_check
   drain.sh.erb: bin/drain
   droplets_ca_cert.pem.erb: config/certs/droplets_ca_cert.pem
   local_blobstore_downloads.conf.erb: config/local_blobstore_downloads.conf

--- a/jobs/cloud_controller_ng/templates/dns_health_check.erb
+++ b/jobs/cloud_controller_ng/templates/dns_health_check.erb
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-nc -z 127.0.0.1 <%= p("cc.external_port") %>
-
-# http://www.consul.io/docs/agent/checks.html
-if [ $? -ne 0 ]; then
-  exit 2 # Exit higher than 1 to ensure service is registered as 'critical'
-fi


### PR DESCRIPTION
* A short explanation of the proposed change:
This health check script is a leftover from the Consul era. Now it's dead code and we propose to remove it.

* An explanation of the use cases your change solves
Removes dead code.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
Built dev capi release and deployed cf, api jobs are starting as usual.