### PR TITLE
New Spec Parameter for Clock job

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -145,6 +145,10 @@ properties:
     description: "How often operations stuck in state 'create'/'initial' should be cleaned up."
     default: 300 # 5 minutes
 
+  cc.service_operations_create_in_progress_cleanup.frequency_in_seconds:
+    description: "How often operations stuck in state 'in progress' should be cleaned up."
+    default: 3600 # 1 hour
+
   cc.external_protocol:
     default: "https"
     description: "The protocol used to access the CC API from an external entity"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -110,6 +110,9 @@ pollable_jobs:
 service_operations_initial_cleanup:
   frequency_in_seconds: <%= p("cc.service_operations_initial_cleanup.frequency_in_seconds") %>
 
+service_operations_create_in_progress_cleanup:
+  frequency_in_seconds: <%= p("cc.service_operations_create_in_progress_cleanup.frequency_in_seconds") %>
+
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>
 


### PR DESCRIPTION
Add **service_operations_create_in_progress_cleanup** frequency as a configurable BOSH property in the clock job, defaulting to 1 hour.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/5011

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
