### PR TITLE
Update release docs

### DIFF
--- a/docs/releasing-capi.md
+++ b/docs/releasing-capi.md
@@ -11,9 +11,8 @@
     - Unpause the `bump-capi-release` job.
 1. **Fill out the release and publish it**
     - The `ship-it` pipeline should have created a draft GitHub release.
-    - Paste in the release notes from the [generate-release-notes job](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/generate-release-notes) into the relevant sections in the release draft.
-    - Add a section about new [Cloud Controller Database Migrations](https://github.com/cloudfoundry/cloud_controller_ng/tree/main/db/migrations).
     - Add any highlights to the top of the release notes.
+    - Complete the "Pull Requests and Issues" section at the end (or delete it).
     - Publish the release.
 1. **Follow-ups**
     - Tell folks you shipped it.


### PR DESCRIPTION
* A short explanation of the proposed change:
Update release procedure documentation. The jobs "push-github-release" and "generate-release-notes" have been harmonized.

* An explanation of the use cases your change solves

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-ci/pull/197

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
