### PR TITLE
Add admin_limit to cc.rate_limiter configuration

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1173,6 +1173,9 @@ properties:
   cc.rate_limiter.unauthenticated_limit:
     description: "The number of requests that an unauthenticated client is allowed to make over an hour-long interval"
     default: 100
+  cc.rate_limiter.admin_limit:
+    description: "The number of requests an admin user or client is allowed to make over the configured interval. Set to -1 for no limit."
+    default: -1
   cc.rate_limiter.reset_interval_in_minutes:
     description: "The interval in minutes after which a user's available API requests will be reset"
     default: 60

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -508,6 +508,8 @@ rate_limiter:
   per_process_general_limit: <%= (p("cc.rate_limiter.general_limit").to_f/instances).ceil %>
   global_unauthenticated_limit: <%= p("cc.rate_limiter.unauthenticated_limit") %>
   per_process_unauthenticated_limit: <%= (p("cc.rate_limiter.unauthenticated_limit").to_f/instances).ceil %>
+  global_admin_limit: <%= p("cc.rate_limiter.admin_limit") %>
+  per_process_admin_limit: <%= p("cc.rate_limiter.admin_limit") == -1 ? -1 : (p("cc.rate_limiter.admin_limit").to_f/instances).ceil %>
   reset_interval_in_minutes: <%= p("cc.rate_limiter.reset_interval_in_minutes") %>
 
 max_concurrent_service_broker_requests: <%= p("cc.max_concurrent_service_broker_requests") %>


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Expose the new cc.rate_limiter.admin_limit BOSH property introduced in the corresponding cloud_controller_ng PR. When set to a positive value, admin users are rate limited independently from general users. Default is -1 (no limit, preserving existing behavior).
* An explanation of the use cases your change solves
Operators can now configure admin rate limits via BOSH manifest.
* Links to any other associated PRs
cloud_controller_ng PR: <https://github.com/cloudfoundry/cloud_controller_ng/pull/5149)>
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
