### PR TITLE
Remove fog AzureRM legacy support from capi-release templates and specs

### DIFF
--- a/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
@@ -25,9 +25,7 @@ scope = "cc.buildpacks.connection_config"
 provider = l.p("cc.buildpacks.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
@@ -25,9 +25,7 @@ scope = "cc.droplets.connection_config"
 provider = l.p("cc.droplets.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
@@ -25,9 +25,7 @@ scope = "cc.packages.connection_config"
 provider = l.p("cc.packages.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
@@ -25,9 +25,7 @@ scope = "cc.resource_pool.connection_config"
 provider = l.p("cc.resource_pool.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
@@ -25,9 +25,7 @@ scope = "cc.buildpacks.connection_config"
 provider = l.p("cc.buildpacks.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
@@ -25,9 +25,7 @@ scope = "cc.droplets.connection_config"
 provider = l.p("cc.droplets.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
@@ -25,9 +25,7 @@ scope = "cc.packages.connection_config"
 provider = l.p("cc.packages.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
@@ -25,9 +25,7 @@ scope = "cc.resource_pool.connection_config"
 provider = l.p("cc.resource_pool.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = l.p("#{scope}.azure_storage_account_name")
   options["container_name"] = l.p("#{scope}.container_name")

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -188,7 +188,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.resource_pool.connection_config:
       description: "Azure Storage Cli connection hash"
@@ -239,7 +239,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -287,7 +287,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -332,7 +332,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -188,7 +188,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
       description: "Azure Storage Cli connection hash"
@@ -239,7 +239,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -287,7 +287,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -332,7 +332,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
@@ -23,9 +23,7 @@ scope = "cc.buildpacks.connection_config"
 provider = p("cc.buildpacks.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
@@ -23,9 +23,7 @@ scope = "cc.droplets.connection_config"
 provider = p("cc.droplets.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
@@ -23,9 +23,7 @@ scope = "cc.packages.connection_config"
 provider = p("cc.packages.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
@@ -23,9 +23,7 @@ scope = "cc.resource_pool.connection_config"
 provider = p("cc.resource_pool.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -531,7 +531,7 @@ properties:
     description: "Storage Cli extra flags string"
     
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.resource_pool.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -584,7 +584,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -637,7 +637,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -687,7 +687,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -531,7 +531,7 @@ properties:
     description: "Storage Cli extra flags string"
     
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -584,7 +584,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -637,7 +637,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -687,7 +687,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -23,8 +23,6 @@ end
 def enable_fog_debugging!(config)
     if p("cc.log_fog_requests")
         case p("cc.packages.fog_connection.provider", "").downcase
-        when "azurerm"
-          config["env"]["FOG_DEBUG"] = true
         when  "aliyun"
           config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
           config["env"]["FOG_DEBUG"] = true

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
@@ -23,9 +23,7 @@ scope = "cc.buildpacks.connection_config"
 provider = p("cc.buildpacks.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
@@ -23,9 +23,7 @@ scope = "cc.droplets.connection_config"
 provider = p("cc.droplets.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
@@ -23,9 +23,7 @@ scope = "cc.packages.connection_config"
 provider = p("cc.packages.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
@@ -23,9 +23,7 @@ scope = "cc.resource_pool.connection_config"
 provider = p("cc.resource_pool.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -150,7 +150,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -201,7 +201,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -249,7 +249,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -294,7 +294,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -150,7 +150,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.resource_pool.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -201,7 +201,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.packages.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -249,7 +249,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.droplets.connection_config:
     description: "Azure Storage Cli connection hash"
@@ -294,7 +294,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AzureRM', 'AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs'] (native) or ['AWS', 'aliyun', 'Google'] (legacy, to be removed May 2026)"
     default: ~
   cc.buildpacks.connection_config:
     description: "Azure Storage Cli connection hash"

--- a/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -36,8 +36,6 @@ config = { "processes" => [] }
 
   if p("cc.log_fog_requests")
         case p("cc.packages.fog_connection.provider", "").downcase
-        when "azurerm"
-          worker_config["env"]["FOG_DEBUG"] = true
         when  "aliyun"
           worker_config["env"]["ALIYUN_OSS_SDK_LOG_LEVEL"] = "debug"
           worker_config["env"]["FOG_DEBUG"] = true

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
@@ -23,9 +23,7 @@ scope = "cc.buildpacks.connection_config"
 provider = p("cc.buildpacks.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
@@ -23,9 +23,7 @@ scope = "cc.droplets.connection_config"
 provider = p("cc.droplets.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
@@ -23,9 +23,7 @@ scope = "cc.packages.connection_config"
 provider = p("cc.packages.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
@@ -23,9 +23,7 @@ scope = "cc.resource_pool.connection_config"
 provider = p("cc.resource_pool.blobstore_provider", nil)
 options = {}
 
-# Support both native storage-cli types (azurebs) AND legacy fog names (AzureRM)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "AzureRM" || provider == "azurebs"
+if provider == "azurebs"
   options["provider"] = provider
   options["account_name"]   = p("#{scope}.azure_storage_account_name")
   options["container_name"] = p("#{scope}.container_name")

--- a/spec/blobstore_benchmark/blobstore_benchmark_spec.rb
+++ b/spec/blobstore_benchmark/blobstore_benchmark_spec.rb
@@ -20,7 +20,7 @@ module Bosh
               'logging' => { 'format' => { 'timestamp' => 'rfc3339' } },
 
               'resource_pool' => {
-                'blobstore_provider' => 'AzureRM',
+                'blobstore_provider' => 'azurebs',
                 'blobstore_type' => 'storage-cli',
                 'connection_config' => {
                   'azure_storage_account_name' => 'acct',
@@ -30,7 +30,7 @@ module Bosh
                 }
               },
               'buildpacks' => {
-                'blobstore_provider' => 'AzureRM',
+                'blobstore_provider' => 'azurebs',
                 'blobstore_type' => 'storage-cli',
                 'connection_config' => {
                   'azure_storage_account_name' => 'acct',
@@ -40,7 +40,7 @@ module Bosh
                 }
               },
               'packages' => {
-                'blobstore_provider' => 'AzureRM',
+                'blobstore_provider' => 'azurebs',
                 'blobstore_type' => 'storage-cli',
                 'connection_config' => {
                   'azure_storage_account_name' => 'acct',
@@ -50,7 +50,7 @@ module Bosh
                 }
               },
               'droplets' => {
-                'blobstore_provider' => 'AzureRM',
+                'blobstore_provider' => 'azurebs',
                 'blobstore_type' => 'storage-cli',
                 'connection_config' => {
                   'azure_storage_account_name' => 'acct',

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -59,8 +59,8 @@ module Bosh
           end
         end
 
-        describe 'when provider is AzureRM' do
-          let(:link_props) { props_for_provider('AzureRM') }
+        describe 'when provider is azurebs' do
+          let(:link_props) { props_for_provider('azurebs') }
           let(:cc_link) do
             Bosh::Template::Test::Link.new(
               name: 'cloud_controller_internal',
@@ -76,7 +76,7 @@ module Bosh
 
               it 'renders and normalizes put_timeout_in_seconds to "41" when blank' do
                 set(link_props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',
@@ -84,7 +84,7 @@ module Bosh
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'AzureRM',
+                  'provider' => 'azurebs',
                   'account_name' => 'acc',
                   'account_key' => 'key',
                   'container_name' => 'cont',
@@ -94,7 +94,7 @@ module Bosh
 
               it 'keeps existing put_timeout_in_seconds when provided' do
                 set(link_props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -52,8 +52,8 @@ module Bosh
           end
         end
 
-        describe 'when provider is AzureRM' do
-          let(:props) { props_for_provider('AzureRM') }
+        describe 'when provider is azurebs' do
+          let(:props) { props_for_provider('azurebs') }
 
           TEMPLATES.each_value do |(template_path, keypath)|
             describe template_path do
@@ -61,7 +61,7 @@ module Bosh
 
               it 'renders and normalizes put_timeout_in_seconds to "41" when blank' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',
@@ -69,7 +69,7 @@ module Bosh
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'AzureRM',
+                  'provider' => 'azurebs',
                   'account_name' => 'acc',
                   'account_key' => 'key',
                   'container_name' => 'cont',
@@ -79,7 +79,7 @@ module Bosh
 
               it 'keeps existing put_timeout_in_seconds when provided' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',

--- a/spec/cloud_controller_ng/bpm_spec.rb
+++ b/spec/cloud_controller_ng/bpm_spec.rb
@@ -39,9 +39,6 @@ module Bosh
         let(:properties_debug_gcp) do
           { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'Google' } } } }
         end
-        let(:properties_debug_azure) do
-          { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'AzureRm' } } } }
-        end
         let(:properties_debug_ali) do
           { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'aliyun' } } } }
         end
@@ -62,18 +59,6 @@ module Bosh
               results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
               expect(results.length).to eq(1)
               expect_default_debug_env_vars(results[0]['env'])
-            end
-
-            it 'sets the FOG_DEBUG env var for Azure' do
-              template_hash = YAML.safe_load(template.render(properties_debug_azure, consumes: {}))
-
-              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-              expect(results.length).to eq(1)
-              env_vars = results[0]['env']
-              expect(env_vars).not_to have_key('DEBUG')
-              expect(env_vars).to have_key('FOG_DEBUG')
-              expect(env_vars).not_to have_key('ALIYUN_OSS_SDK_LOG_LEVEL')
-              expect(env_vars['FOG_DEBUG']).to be(true)
             end
 
             it 'sets the ALIYUN_OSS_SDK_LOG_LEVEL env var for Ali' do

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -53,8 +53,8 @@ module Bosh
           end
         end
 
-        describe 'when provider is AzureRM' do
-          let(:props) { props_for_provider('AzureRM') }
+        describe 'when provider is azurebs' do
+          let(:props) { props_for_provider('azurebs') }
 
           TEMPLATES.each_value do |(template_path, keypath)|
             describe template_path do
@@ -62,7 +62,7 @@ module Bosh
 
               it 'renders and normalizes put_timeout_in_seconds to "41" when blank' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',
@@ -70,7 +70,7 @@ module Bosh
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'AzureRM',
+                  'provider' => 'azurebs',
                   'account_name' => 'acc',
                   'account_key' => 'key',
                   'container_name' => 'cont',
@@ -80,7 +80,7 @@ module Bosh
 
               it 'keeps existing put_timeout_in_seconds when provided' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -52,8 +52,8 @@ module Bosh
           end
         end
 
-        describe 'when provider is AzureRM' do
-          let(:props) { props_for_provider('AzureRM') }
+        describe 'when provider is azurebs' do
+          let(:props) { props_for_provider('azurebs') }
 
           TEMPLATES.each_value do |(template_path, keypath)|
             describe template_path do
@@ -61,7 +61,7 @@ module Bosh
 
               it 'renders and normalizes put_timeout_in_seconds to "41" when blank' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',
@@ -69,7 +69,7 @@ module Bosh
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'AzureRM',
+                  'provider' => 'azurebs',
                   'account_name' => 'acc',
                   'account_key' => 'key',
                   'container_name' => 'cont',
@@ -79,7 +79,7 @@ module Bosh
 
               it 'keeps existing put_timeout_in_seconds when provided' do
                 set(props, keypath, {
-                      'provider' => 'AzureRM',
+                      'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
                       'azure_storage_access_key' => 'key',
                       'container_name' => 'cont',


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Remove fog AzureRM legacy support from capi-release.

* An explanation of the use cases your change solves
 The fog-azure-rm gem will be removed from cloud_controller_ng. The storage-cli client no longer accepts AzureRM as a legacy provider name. Operators should use azurebs as the provider value going forward.
* Links to any other associated PRs
cloud_controller_ng <https://github.com/cloudfoundry/cloud_controller_ng/pull/5118>

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
