### PR TITLE
Rename dea_next staging params to cc section

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1048,19 +1048,15 @@ properties:
   cc.thresholds.api.restart_if_consistently_above_memory_percent:
     description: "The cc will restart if memory remains above this percent threshold for n monit cycles. If specified, this threshold is used over `cc.thresholds.api.restart_if_consistently_above_mb` and `restart_if_above_mb`. Value must be percent integer, e.g. '80'."
 
-  dea_next.staging_memory_limit_mb:
-    description: "Memory limit in MB for staging tasks"
+  cc.minimum_staging_memory_mb:
+    description: "Minimum memory in MB guaranteed for staging tasks. A staging task will get at least this amount of memory, even if the app is configured with less."
     default: 1024
-  dea_next.staging_disk_limit_mb:
-    description: "Disk limit in MB for staging tasks"
+  cc.minimum_staging_disk_mb:
+    description: "Minimum disk space in MB guaranteed for staging tasks. A staging task will get at least this amount of disk, even if the app is configured with less."
     default: 4096
   cc.staging_file_descriptor_limit:
-    description: "File descriptor limit for staging tasks"
+    description: "Minimum number of file descriptors guaranteed for staging tasks. A staging task will get at least this many file descriptors."
     default: 16384
-
-  dea_next.advertise_interval_in_seconds:
-    description: "Advertise interval for DEAs"
-    default: 5
   cc.renderer.max_results_per_page:
     description: "Maximum number of results returned per page"
     default: 100

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -295,8 +295,8 @@ credential_references:
 staging:
   legacy_md5_buildpack_paths_enabled: <%= p("cc.legacy_md5_buildpack_paths_enabled") %>
   timeout_in_seconds: <%= p("cc.staging_timeout_in_seconds") %>
-  minimum_staging_memory_mb: <%= p("dea_next.staging_memory_limit_mb") %>
-  minimum_staging_disk_mb: <%= p("dea_next.staging_disk_limit_mb") %>
+  minimum_staging_memory_mb: <%= p("cc.minimum_staging_memory_mb") %>
+  minimum_staging_disk_mb: <%= p("cc.minimum_staging_disk_mb") %>
   minimum_staging_file_descriptor_limit: <%= p("cc.staging_file_descriptor_limit") %>
   auth:
     user: <%= p("cc.staging_upload_user") %>


### PR DESCRIPTION
Replace historic dea_next.staging_memory_limit_mb and dea_next.staging_disk_limit_mb with cc.minimum_staging_memory_mb and cc.minimum_staging_disk_mb to better reflect their semantics as minimum (not limit) values. Remove unused dea_next.advertise_interval_in_seconds.

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
   Rename dea_next staging params to cc section. Remove unused dea_next.advertise_interval_in_seconds.

   Replace historic dea_next.staging_memory_limit_mb and dea_next.staging_disk_limit_mb 
   with cc.minimum_staging_memory_mb and cc.minimum_staging_disk_mb
* An explanation of the use cases your change solves
   New parameter better reflect their semantics as minimum values.
* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
