### PR TITLE
Add configurable CCDB connection parameters

### DIFF
--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -91,6 +91,18 @@ properties:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.psql.statement_timeout:
+    description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+  ccdb.psql.idle_in_transaction_session_timeout:
+    description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+  ccdb.psql.keepalives:
+    description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+  ccdb.psql.keepalives_idle:
+    description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_interval:
+    description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_count:
+    description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
 
   cc.readiness_port.deployment_updater:
     default: -1

--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -93,16 +93,22 @@ properties:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.psql.statement_timeout:
     description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+    default: 1800000
   ccdb.psql.idle_in_transaction_session_timeout:
     description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+    default: 600000
   ccdb.psql.keepalives:
     description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+    default: 1
   ccdb.psql.keepalives_idle:
     description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+    default: 30
   ccdb.psql.keepalives_interval:
     description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+    default: 10
   ccdb.psql.keepalives_count:
     description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
+    default: 3
 
   cc.readiness_port.deployment_updater:
     default: -1

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -78,6 +78,27 @@ db: &db
 <% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
   connection_expiration_random_delay: <%= expiration_delay %>
 <% end %>
+<% if_p("ccdb.psql.statement_timeout", "ccdb.psql.idle_in_transaction_session_timeout", "ccdb.psql.keepalives", "ccdb.psql.keepalives_idle", "ccdb.psql.keepalives_interval", "ccdb.psql.keepalives_count") do %>
+  psql:
+<% if_p("ccdb.psql.statement_timeout") do |v| %>
+    statement_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.idle_in_transaction_session_timeout") do |v| %>
+    idle_in_transaction_session_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives") do |v| %>
+    keepalives: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_idle") do |v| %>
+    keepalives_idle: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_interval") do |v| %>
+    keepalives_interval: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_count") do |v| %>
+    keepalives_count: <%= v %>
+<% end %>
+<% end %>
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -420,16 +420,22 @@ properties:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.psql.statement_timeout:
     description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+    default: 1800000
   ccdb.psql.idle_in_transaction_session_timeout:
     description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+    default: 600000
   ccdb.psql.keepalives:
     description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+    default: 1
   ccdb.psql.keepalives_idle:
     description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+    default: 30
   ccdb.psql.keepalives_interval:
     description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+    default: 10
   ccdb.psql.keepalives_count:
     description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
+    default: 3
   uaa.ca_cert:
     description: "The certificate authority being used by UAA"
   uaa.ssl.port:

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -418,7 +418,18 @@ properties:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
-
+  ccdb.psql.statement_timeout:
+    description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+  ccdb.psql.idle_in_transaction_session_timeout:
+    description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+  ccdb.psql.keepalives:
+    description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+  ccdb.psql.keepalives_idle:
+    description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_interval:
+    description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_count:
+    description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
   uaa.ca_cert:
     description: "The certificate authority being used by UAA"
   uaa.ssl.port:

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -179,6 +179,27 @@ db: &db
 <% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
   connection_expiration_random_delay: <%= expiration_delay %>
 <% end %>
+<% if_p("ccdb.psql.statement_timeout", "ccdb.psql.idle_in_transaction_session_timeout", "ccdb.psql.keepalives", "ccdb.psql.keepalives_idle", "ccdb.psql.keepalives_interval", "ccdb.psql.keepalives_count") do %>
+  psql:
+<% if_p("ccdb.psql.statement_timeout") do |v| %>
+    statement_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.idle_in_transaction_session_timeout") do |v| %>
+    idle_in_transaction_session_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives") do |v| %>
+    keepalives: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_idle") do |v| %>
+    keepalives_idle: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_interval") do |v| %>
+    keepalives_interval: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_count") do |v| %>
+    keepalives_count: <%= v %>
+<% end %>
+<% end %>
 
 <% system_domain = p("system_domain") %>
 

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -783,6 +783,18 @@ properties:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.psql.statement_timeout:
+    description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+  ccdb.psql.idle_in_transaction_session_timeout:
+    description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+  ccdb.psql.keepalives:
+    description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+  ccdb.psql.keepalives_idle:
+    description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_interval:
+    description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_count:
+    description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
   ccdb.max_connections_per_local_worker:
     description: "Maximum database connections per cc local worker, if not set the ccng value is used (default)"
   ccdb.enable_paginate_window:

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -785,16 +785,22 @@ properties:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.psql.statement_timeout:
     description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+    default: 900000
   ccdb.psql.idle_in_transaction_session_timeout:
     description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+    default: 600000
   ccdb.psql.keepalives:
     description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+    default: 1
   ccdb.psql.keepalives_idle:
     description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+    default: 30
   ccdb.psql.keepalives_interval:
     description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+    default: 10
   ccdb.psql.keepalives_count:
     description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
+    default: 3
   ccdb.max_connections_per_local_worker:
     description: "Maximum database connections per cc local worker, if not set the ccng value is used (default)"
   ccdb.enable_paginate_window:

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -241,6 +241,27 @@ db: &db
   migration_psql_worker_memory_kb: <%= psql_worker_memory_kb %>
 <% end %>
   enable_paginate_window: <%= p("ccdb.enable_paginate_window") %>
+<% if_p("ccdb.psql.statement_timeout", "ccdb.psql.idle_in_transaction_session_timeout", "ccdb.psql.keepalives", "ccdb.psql.keepalives_idle", "ccdb.psql.keepalives_interval", "ccdb.psql.keepalives_count") do %>
+  psql:
+<% if_p("ccdb.psql.statement_timeout") do |v| %>
+    statement_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.idle_in_transaction_session_timeout") do |v| %>
+    idle_in_transaction_session_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives") do |v| %>
+    keepalives: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_idle") do |v| %>
+    keepalives_idle: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_interval") do |v| %>
+    keepalives_interval: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_count") do |v| %>
+    keepalives_count: <%= v %>
+<% end %>
+<% end %>
 
 <% scheme = p("login.protocol")
    system_domain = p("system_domain") %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -377,6 +377,18 @@ properties:
     description: "The period in seconds after which connections are expired (omit to never expire connections), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.connection_expiration_random_delay:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
+  ccdb.psql.statement_timeout:
+    description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+  ccdb.psql.idle_in_transaction_session_timeout:
+    description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+  ccdb.psql.keepalives:
+    description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+  ccdb.psql.keepalives_idle:
+    description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_interval:
+    description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+  ccdb.psql.keepalives_count:
+    description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
 
   cc.database_encryption.keys:
     default: {}

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -379,16 +379,22 @@ properties:
     description: "The random delay in seconds to the expiration timeout (to prevent all connections being recreated simultaneously), passed directly to the Sequel gem - see https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_expiration_rb.html for details"
   ccdb.psql.statement_timeout:
     description: "PostgreSQL statement_timeout in milliseconds - kills queries that run longer than this value (PostgreSQL only)"
+    default: 1800000
   ccdb.psql.idle_in_transaction_session_timeout:
     description: "PostgreSQL idle_in_transaction_session_timeout in milliseconds - closes sessions that remain idle in a transaction longer than this value (PostgreSQL only)"
+    default: 600000
   ccdb.psql.keepalives:
     description: "Enable TCP keepalives for PostgreSQL connections (1 to enable, 0 to disable; PostgreSQL only)"
+    default: 1
   ccdb.psql.keepalives_idle:
     description: "Seconds of idle time before TCP keepalives are sent for PostgreSQL connections (PostgreSQL only)"
+    default: 30
   ccdb.psql.keepalives_interval:
     description: "Seconds between TCP keepalive retransmissions for PostgreSQL connections (PostgreSQL only)"
+    default: 10
   ccdb.psql.keepalives_count:
     description: "Maximum number of TCP keepalive retransmissions before the connection is considered dead (PostgreSQL only)"
+    default: 3
 
   cc.database_encryption.keys:
     default: {}

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -134,6 +134,27 @@ db: &db
 <% if_p("ccdb.connection_expiration_random_delay") do |expiration_delay| %>
   connection_expiration_random_delay: <%= expiration_delay %>
 <% end %>
+<% if_p("ccdb.psql.statement_timeout", "ccdb.psql.idle_in_transaction_session_timeout", "ccdb.psql.keepalives", "ccdb.psql.keepalives_idle", "ccdb.psql.keepalives_interval", "ccdb.psql.keepalives_count") do %>
+  psql:
+<% if_p("ccdb.psql.statement_timeout") do |v| %>
+    statement_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.idle_in_transaction_session_timeout") do |v| %>
+    idle_in_transaction_session_timeout: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives") do |v| %>
+    keepalives: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_idle") do |v| %>
+    keepalives_idle: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_interval") do |v| %>
+    keepalives_interval: <%= v %>
+<% end %>
+<% if_p("ccdb.psql.keepalives_count") do |v| %>
+    keepalives_count: <%= v %>
+<% end %>
+<% end %>
 
 <% system_domain = p("system_domain") %>
 


### PR DESCRIPTION
* A short explanation of the proposed change:
  Currently CC relies on connection timeouts configured globally at the CCDB level (e.g. `statement_timeout = 1h`, `idle_in_transaction_session_timeout = 10min`). With this feature, these settings are now configurable in the BOSH manifest alongside other Cloud Controller (CC) configuration, without requiring direct database access.

* Links to any other associated PRs
[Add configurable CCDB connection parameters
](https://github.com/cloudfoundry/cloud_controller_ng/pull/5260)

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
