### PR TITLE
Remove fog-google support from storage-cli templates and specs

### DIFF
--- a/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
@@ -35,9 +35,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  l.p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -193,7 +193,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
       description: "Storage CLI connection configuration"
@@ -244,7 +244,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Storage CLI connection configuration"
@@ -292,7 +292,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Storage CLI connection configuration"
@@ -337,7 +337,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Storage CLI connection configuration"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -532,7 +532,7 @@ properties:
     description: "Storage Cli extra flags string"
     
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
     description: "Storage CLI connection configuration"
@@ -585,7 +585,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Storage CLI connection configuration"
@@ -638,7 +638,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Storage CLI connection configuration"
@@ -688,7 +688,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Storage CLI connection configuration"

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -150,7 +150,7 @@ properties:
     description: "Storage Cli extra flags string"
 
   cc.resource_pool.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.resource_pool.connection_config:
     description: "Storage CLI connection configuration"
@@ -201,7 +201,7 @@ properties:
     default: ""
 
   cc.packages.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.packages.connection_config:
     description: "Storage CLI connection configuration"
@@ -249,7 +249,7 @@ properties:
     default: ""
 
   cc.droplets.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.droplets.connection_config:
     description: "Storage CLI connection configuration"
@@ -294,7 +294,7 @@ properties:
     default: ""
 
   cc.buildpacks.blobstore_provider:
-    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS', 'Google'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
+    description: "The provider of blobstore storage cli to use. Valid values: ['azurebs', 's3', 'alioss', 'gcs', 'dav'] (native) or ['AWS'] (legacy, to be removed May 2026). Note: 'AzureRM' is no longer a valid provider, use 'azurebs' instead."
     default: ~
   cc.buildpacks.connection_config:
     description: "Storage CLI connection configuration"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
@@ -33,9 +33,7 @@ if provider == "azurebs"
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 
-# Support both native storage-cli types (gcs) AND legacy fog names (Google)
-# Legacy fog name support to be REMOVED May 2026
-if provider == "Google" || provider == "gcs"
+if provider == "gcs"
   options["provider"] = provider
   options["credentials_source"] = "static"
   options["json_key"] =  p("#{scope}.google_json_key_string")

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -222,7 +222,7 @@ module Bosh
         end
 
         describe 'when provider is Google' do
-          let(:link_props) { props_for_provider('Google') }
+          let(:link_props) { props_for_provider('gcs') }
           let(:cc_link) do
             Bosh::Template::Test::Link.new(
               name: 'cloud_controller_internal',
@@ -238,13 +238,13 @@ module Bosh
 
               it 'maps required properties into the rendered config' do
                 set(link_props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}'
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static'
@@ -253,7 +253,7 @@ module Bosh
 
               it 'includes optional properties when provided' do
                 set(link_props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
@@ -263,7 +263,7 @@ module Bosh
 
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static',

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -199,7 +199,7 @@ module Bosh
         end
 
         describe 'when provider is Google' do
-          let(:props) { props_for_provider('Google') }
+          let(:props) { props_for_provider('gcs') }
 
           storage_cli_templates.each do |(template_path, keypath)|
             describe template_path do
@@ -207,13 +207,13 @@ module Bosh
 
               it 'maps required properties into the rendered config' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}'
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static'
@@ -222,7 +222,7 @@ module Bosh
 
               it 'includes optional properties when provided' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
@@ -232,7 +232,7 @@ module Bosh
 
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static',

--- a/spec/cloud_controller_ng/bpm_spec.rb
+++ b/spec/cloud_controller_ng/bpm_spec.rb
@@ -35,11 +35,8 @@ module Bosh
         let(:release) { ReleaseDir.new(release_path) }
         let(:job) { release.job('cloud_controller_ng') }
 
-        let(:properties_debug_gcp) do
-          { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'Google' } } } }
-        end
-        let(:properties_debug_foo) do
-          { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'foo' } } } }
+        let(:properties_debug_fog) do
+          { 'cc' => { 'log_fog_requests' => true, 'packages' => { 'fog_connection' => { 'provider' => 'AWS' } } } }
         end
         let(:properties_without_debug) do
           { 'cc' => { 'log_fog_requests' => false, 'packages' => { 'fog_connection' => { 'provider' => 'foo' } } } }
@@ -49,16 +46,8 @@ module Bosh
           let(:template) { job.template('config/bpm.yml') }
 
           context 'when fog debug logging is enabled' do
-            it 'sets the DEBUG env var for GCP' do
-              template_hash = YAML.safe_load(template.render(properties_debug_gcp, consumes: {}))
-
-              results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
-              expect(results.length).to eq(1)
-              expect_default_debug_env_vars(results[0]['env'])
-            end
-
-            it 'sets not any debug env var for Foo' do
-              template_hash = YAML.safe_load(template.render(properties_debug_foo, consumes: {}))
+            it 'sets the DEBUG env var' do
+              template_hash = YAML.safe_load(template.render(properties_debug_fog, consumes: {}))
 
               results = template_hash['processes'].select { |p| p['name'].include?('cloud_controller_ng') }
               expect(results.length).to eq(1)

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -199,7 +199,7 @@ module Bosh
         end
 
         describe 'when provider is Google' do
-          let(:props) { props_for_provider('Google') }
+          let(:props) { props_for_provider('gcs') }
 
           storage_cli_templates.each do |(template_path, keypath)|
             describe template_path do
@@ -207,13 +207,13 @@ module Bosh
 
               it 'maps required properties into the rendered config' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}'
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static'
@@ -222,7 +222,7 @@ module Bosh
 
               it 'includes optional properties when provided' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
@@ -232,7 +232,7 @@ module Bosh
 
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static',

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -199,7 +199,7 @@ module Bosh
         end
 
         describe 'when provider is Google' do
-          let(:props) { props_for_provider('Google') }
+          let(:props) { props_for_provider('gcs') }
 
           storage_cli_templates.each do |(template_path, keypath)|
             describe template_path do
@@ -207,13 +207,13 @@ module Bosh
 
               it 'maps required properties into the rendered config' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}'
                     })
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static'
@@ -222,7 +222,7 @@ module Bosh
 
               it 'includes optional properties when provided' do
                 set(props, keypath, {
-                      'provider' => 'Google',
+                      'provider' => 'gcs',
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
@@ -232,7 +232,7 @@ module Bosh
 
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json).to include(
-                  'provider' => 'Google',
+                  'provider' => 'gcs',
                   'bucket_name' => 'bucket',
                   'json_key' => '{}',
                   'credentials_source' => 'static',


### PR DESCRIPTION
Remove fog-google support from storage-cli templates and specs

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/5261
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
