### PR TITLE
Add missing storage-cli S3 config parameters to blobstore templates

### DIFF
--- a/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
@@ -75,6 +75,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", l.p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", l.p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", l.p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", l.p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"
@@ -82,7 +86,7 @@ if provider == "alioss"
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
 end
-  
+
 # Support both native storage-cli types (dav) AND legacy fog names (webdav)
 # Legacy fog name support to be REMOVED May 2026
 if provider == "webdav" || provider == "dav"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"
@@ -82,7 +86,7 @@ if provider == "alioss"
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
 end
-  
+
 # Support both native storage-cli types (dav) AND legacy fog names (webdav)
 # Legacy fog name support to be REMOVED May 2026
 if provider == "webdav" || provider == "dav"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
@@ -73,6 +73,10 @@ if provider == "AWS" || provider == "s3"
   add_optional(options, "upload_part_size", p("#{scope}.upload_part_size", nil))
   add_optional(options, "multipart_copy_threshold", p("#{scope}.multipart_copy_threshold", nil))
   add_optional(options, "multipart_copy_part_size", p("#{scope}.multipart_copy_part_size", nil))
+  add_optional(options, "single_upload_threshold", p("#{scope}.single_upload_threshold", nil))
+  add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
+  add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
+  add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
 end
 
 if provider == "alioss"

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -188,7 +188,11 @@ module Bosh
                       'upload_concurrency' => 10,
                       'upload_part_size' => 2048,
                       'multipart_copy_threshold' => 1024,
-                      'multipart_copy_part_size' => 1024
+                      'multipart_copy_part_size' => 1024,
+                      'single_upload_threshold' => 2048,
+                      'request_checksum_calculation_enabled' => false,
+                      'response_checksum_calculation_enabled' => false,
+                      'uploader_request_checksum_calculation_enabled' => false
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -214,7 +218,11 @@ module Bosh
                   'upload_concurrency' => 10,
                   'upload_part_size' => 2048,
                   'multipart_copy_threshold' => 1024,
-                  'multipart_copy_part_size' => 1024
+                  'multipart_copy_part_size' => 1024,
+                  'single_upload_threshold' => 2048,
+                  'request_checksum_calculation_enabled' => false,
+                  'response_checksum_calculation_enabled' => false,
+                  'uploader_request_checksum_calculation_enabled' => false
                 )
               end
             end

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -165,7 +165,11 @@ module Bosh
                       'upload_concurrency' => 10,
                       'upload_part_size' => 2048,
                       'multipart_copy_threshold' => 1024,
-                      'multipart_copy_part_size' => 1024
+                      'multipart_copy_part_size' => 1024,
+                      'single_upload_threshold' => 2048,
+                      'request_checksum_calculation_enabled' => false,
+                      'response_checksum_calculation_enabled' => false,
+                      'uploader_request_checksum_calculation_enabled' => false
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -191,7 +195,11 @@ module Bosh
                   'upload_concurrency' => 10,
                   'upload_part_size' => 2048,
                   'multipart_copy_threshold' => 1024,
-                  'multipart_copy_part_size' => 1024
+                  'multipart_copy_part_size' => 1024,
+                  'single_upload_threshold' => 2048,
+                  'request_checksum_calculation_enabled' => false,
+                  'response_checksum_calculation_enabled' => false,
+                  'uploader_request_checksum_calculation_enabled' => false
                 )
               end
             end

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -165,7 +165,11 @@ module Bosh
                       'upload_concurrency' => 10,
                       'upload_part_size' => 2048,
                       'multipart_copy_threshold' => 1024,
-                      'multipart_copy_part_size' => 1024
+                      'multipart_copy_part_size' => 1024,
+                      'single_upload_threshold' => 2048,
+                      'request_checksum_calculation_enabled' => false,
+                      'response_checksum_calculation_enabled' => false,
+                      'uploader_request_checksum_calculation_enabled' => false
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -191,7 +195,11 @@ module Bosh
                   'upload_concurrency' => 10,
                   'upload_part_size' => 2048,
                   'multipart_copy_threshold' => 1024,
-                  'multipart_copy_part_size' => 1024
+                  'multipart_copy_part_size' => 1024,
+                  'single_upload_threshold' => 2048,
+                  'request_checksum_calculation_enabled' => false,
+                  'response_checksum_calculation_enabled' => false,
+                  'uploader_request_checksum_calculation_enabled' => false
                 )
               end
             end

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -165,7 +165,11 @@ module Bosh
                       'upload_concurrency' => 10,
                       'upload_part_size' => 2048,
                       'multipart_copy_threshold' => 1024,
-                      'multipart_copy_part_size' => 1024
+                      'multipart_copy_part_size' => 1024,
+                      'single_upload_threshold' => 2048,
+                      'request_checksum_calculation_enabled' => false,
+                      'response_checksum_calculation_enabled' => false,
+                      'uploader_request_checksum_calculation_enabled' => false
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -191,7 +195,11 @@ module Bosh
                   'upload_concurrency' => 10,
                   'upload_part_size' => 2048,
                   'multipart_copy_threshold' => 1024,
-                  'multipart_copy_part_size' => 1024
+                  'multipart_copy_part_size' => 1024,
+                  'single_upload_threshold' => 2048,
+                  'request_checksum_calculation_enabled' => false,
+                  'response_checksum_calculation_enabled' => false,
+                  'uploader_request_checksum_calculation_enabled' => false
                 )
               end
             end


### PR DESCRIPTION
Add missing storage-cli S3 config parameters to blobstore templates:

* A short explanation of the proposed change:
Add missing storage-cli S3 config parameters (`single_upload_threshold`, `request_checksum_calculation_enabled`, `response_checksum_calculation_enabled`, `uploader_request_checksum_calculation_enabled`) to all blobstore JSON templates across all 5 jobs and 4 resource types.
* An explanation of the use cases your change solves
These fields allows operators to:
  - Control whether files are uploaded via a single PutObject call or multipart upload (`single_upload_threshold`)
  - Disable checksum calculation/validation for S3-compatible providers that do not support it (e.g. AliCloud)

All parameters are optional. If not set in the manifest, the key is omitted from the generated JSON and storage-cli applies its own defaults:
  - `single_upload_threshold`: `0` (always use multipart upload)
  - `request_checksum_calculation_enabled`: `true`
  - `response_checksum_calculation_enabled`: `true`
  - `uploader_request_checksum_calculation_enabled`: `true`
* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/issues/672
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
