### PR TITLE
Fix stale nginx upstream keepalive connections causing broken pipe errors

### DIFF
--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -1022,6 +1022,10 @@ properties:
     description: "Configure keep alive timeout for connections to cloud controller. This is a temporary field used for testing."
     default: 100
 
+  cc.nginx_upstream_keepalive_timeout:
+    description: "Keepalive timeout in seconds for nginx upstream connections to Puma. Must be less than cc.puma.persistent_timeout (default 20s) to prevent stale keepalive connections causing broken pipe errors."
+    default: 15
+
   cc.jobs.local.number_of_workers:
     default: 2
     description: "Number of local cloud_controller_worker workers"

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -50,6 +50,8 @@ limit_req_zone $http_authorization zone=<%= zone['name'] %>:10m rate=<%= zone['l
 
   upstream cloud_controller {
     server unix:/var/vcap/data/cloud_controller_ng/cloud_controller.sock;
+    keepalive 32;
+    keepalive_timeout <%= p("cc.nginx_upstream_keepalive_timeout") %>s;
   }
 
   upstream cloud_controller_metrics {

--- a/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -50,7 +50,7 @@ limit_req_zone $http_authorization zone=<%= zone['name'] %>:10m rate=<%= zone['l
 
   upstream cloud_controller {
     server unix:/var/vcap/data/cloud_controller_ng/cloud_controller.sock;
-    keepalive 32;
+    keepalive <%= p("cc.puma.workers") * p("cc.puma.max_threads") %>;
     keepalive_timeout <%= p("cc.nginx_upstream_keepalive_timeout") %>s;
   }
 


### PR DESCRIPTION

* A short explanation of the proposed change:

  Add keepalive_timeout=15s to nginx upstream block so nginx evicts idle connections before Puma closes them (persistent_timeout=20s), preventing writev() EPIPE errors on stale connections.

* An explanation of the use cases your change solves

  This change solves the case where nginx reuses an idle upstream connection to Puma that Puma has already closed. Setting keepalive_timeout=15s, shorter than Puma's persistent_timeout=20s, ensures nginx always evicts idle connections from its pool before Puma closes them. The stale connection window is eliminated entirely.
* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run CF Acceptance Tests on bosh lite
