### PR TITLE
Add clock frequency property for service update in-progress cleanup

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -149,8 +149,8 @@ properties:
     description: "How often operations stuck in state 'in progress' should be cleaned up."
     default: 3600 # 1 hour
 
-  cc.service_operations_update_in_progress_cleanup.frequency_in_seconds:
-    description: "How often 'update' operations stuck in state 'in progress' should be cleaned up."
+  cc.service_operations_update_stuck_in_progress_failed.frequency_in_seconds:
+    description: "How often 'update' operations stuck in state 'in progress' should be marked as 'failed'."
     default: 3600 # 1 hour
 
   # One-off backfill - to be removed in a future version.

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -153,6 +153,10 @@ properties:
     description: "How often 'update' operations stuck in state 'in progress' should be marked as 'failed'."
     default: 3600 # 1 hour
 
+  cc.service_operations_delete_stuck_in_progress_retry.frequency_in_seconds:
+    description: "How often 'delete' operations stuck in state 'in progress' should be retried by re-enqueuing the polling job."
+    default: 3600 # 1 hour
+
   # One-off backfill - to be removed in a future version.
   cc.lifecycle_type_backfill.frequency_in_seconds:
     description: "How often the one-off lifecycle_type backfill job runs"

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -149,6 +149,10 @@ properties:
     description: "How often operations stuck in state 'in progress' should be cleaned up."
     default: 3600 # 1 hour
 
+  cc.service_operations_update_in_progress_cleanup.frequency_in_seconds:
+    description: "How often 'update' operations stuck in state 'in progress' should be cleaned up."
+    default: 3600 # 1 hour
+
   # One-off backfill - to be removed in a future version.
   cc.lifecycle_type_backfill.frequency_in_seconds:
     description: "How often the one-off lifecycle_type backfill job runs"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -113,6 +113,9 @@ service_operations_initial_cleanup:
 service_operations_create_in_progress_cleanup:
   frequency_in_seconds: <%= p("cc.service_operations_create_in_progress_cleanup.frequency_in_seconds") %>
 
+service_operations_update_in_progress_cleanup:
+  frequency_in_seconds: <%= p("cc.service_operations_update_in_progress_cleanup.frequency_in_seconds") %>
+
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>
 

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -113,8 +113,8 @@ service_operations_initial_cleanup:
 service_operations_create_in_progress_cleanup:
   frequency_in_seconds: <%= p("cc.service_operations_create_in_progress_cleanup.frequency_in_seconds") %>
 
-service_operations_update_in_progress_cleanup:
-  frequency_in_seconds: <%= p("cc.service_operations_update_in_progress_cleanup.frequency_in_seconds") %>
+service_operations_update_stuck_in_progress_failed:
+  frequency_in_seconds: <%= p("cc.service_operations_update_stuck_in_progress_failed.frequency_in_seconds") %>
 
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -116,6 +116,9 @@ service_operations_create_in_progress_cleanup:
 service_operations_update_stuck_in_progress_failed:
   frequency_in_seconds: <%= p("cc.service_operations_update_stuck_in_progress_failed.frequency_in_seconds") %>
 
+service_operations_delete_stuck_in_progress_retry:
+  frequency_in_seconds: <%= p("cc.service_operations_delete_stuck_in_progress_retry.frequency_in_seconds") %>
+
 completed_tasks:
   cutoff_age_in_days: <%= p("cc.completed_tasks.cutoff_age_in_days") %>
 


### PR DESCRIPTION
Expose service_operations_update_in_progress_cleanup.frequency_in_seconds as a configurable BOSH property in the clock job, defaulting to 1 hour, mirroring the existing create cleanup property.

* A short explanation of the proposed change:
Adds cc.service_operations_update_in_progress_cleanup.frequency_in_seconds as a configurable BOSH property for the cloud_controller_clock job, defaulting to 1 hour. This controls how often the new ServiceOperationsUpdateInProgressCleanup periodic job  runs.
* An explanation of the use cases your change solves
On CCEE landscapes, CCDB restarts more frequently than on public IaaS providers. If the DB is briefly unavailable during a service broker polling cycle, the CC polling job can fail permanently (max_attempts=1) while the broker is still processing. This leaves a service instance update operation stuck in in progress indefinitely with no delayed job working on it, requiring operator intervention.

The ServiceOperationsUpdateInProgressCleanup job (added in the companion ccng PR) detects these stuck update operations and marks them as failed, giving clients a definitive final state without deprovisioning the underlying resource. This BOSH property allows operators to tune how frequently that cleanup runs.
* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/5359
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
