### PR TITLE
Add "http_request_timeout" option to storage-cli "connection_config" parameter

### DIFF
--- a/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_buildpacks.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_droplets.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_packages.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/blobstore_benchmark/templates/storage_cli_config_resource_pool.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 
@@ -107,6 +110,6 @@ if provider == "dav"
     options["tls"]={"cert"=>{"ca"=>ca_cert}}
   end
 end
-  
+
 -%>
 <%= JSON.pretty_generate(options) %>

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_buildpacks.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,8 +87,9 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
-  
+
 
 if provider == "dav"
   options["provider"] = "dav"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_droplets.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,6 +87,7 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_packages.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
@@ -42,6 +42,7 @@ if provider == "gcs"
   options["bucket_name"] = l.p("#{scope}.bucket_name")
   add_optional(options, "storage_class", l.p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", l.p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -77,6 +78,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", l.p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", l.p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", l.p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -85,8 +87,9 @@ if provider == "alioss"
   options["access_key_secret"] = l.p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = l.p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = l.p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
 end
-  
+
 
 if provider == "dav"
   options["provider"] = "dav"

--- a/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cc_deployment_updater/templates/storage_cli_config_resource_pool.json.erb
@@ -32,6 +32,7 @@ if provider == "azurebs"
   options["account_key"] = l.p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", l.p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", l.p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", l.p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_buildpacks.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_droplets.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_packages.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_clock/templates/storage_cli_config_resource_pool.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
   
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_buildpacks.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_droplets.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_packages.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_ng/templates/storage_cli_config_resource_pool.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
   
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_buildpacks.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_droplets.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,6 +85,7 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_packages.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,8 +85,9 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
-  
+
 
 if provider == "dav"
   options["provider"] = "dav"

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
@@ -30,6 +30,7 @@ if provider == "azurebs"
   options["account_key"] = p("#{scope}.azure_storage_access_key")
   add_optional(options, "environment", p("#{scope}.environment", "AzureCloud"))
   add_optional(options, "put_timeout_in_seconds", p("#{scope}.put_timeout_in_seconds", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
   options = cli_cfg_with_default_timeout(options, 'storage_cli')
 end
 

--- a/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
+++ b/jobs/cloud_controller_worker/templates/storage_cli_config_resource_pool.json.erb
@@ -40,6 +40,7 @@ if provider == "gcs"
   options["bucket_name"] = p("#{scope}.bucket_name")
   add_optional(options, "storage_class", p("#{scope}.storage_class", nil))
   add_optional(options, "encryption_key", p("#{scope}.encryption_key", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "s3"
@@ -75,6 +76,7 @@ if provider == "s3"
   add_optional(options, "request_checksum_calculation_enabled", p("#{scope}.request_checksum_calculation_enabled", nil))
   add_optional(options, "response_checksum_calculation_enabled", p("#{scope}.response_checksum_calculation_enabled", nil))
   add_optional(options, "uploader_request_checksum_calculation_enabled", p("#{scope}.uploader_request_checksum_calculation_enabled", nil))
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
 
 if provider == "alioss"
@@ -83,8 +85,9 @@ if provider == "alioss"
   options["access_key_secret"] = p("#{scope}.aliyun_accesskey_secret")
   options["endpoint"] = p("#{scope}.aliyun_oss_endpoint")
   options["bucket_name"] = p("#{scope}.aliyun_oss_bucket")
+  add_optional(options, "http_request_timeout", p("#{scope}.http_request_timeout", nil))
 end
-
+  
 
 if provider == "dav"
   options["provider"] = "dav"

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -106,7 +106,7 @@ module Bosh
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
 
-              it 'passes http_request_timeout when provided' do
+              it 'includes http_request_timeout when provided' do
                 set(link_props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
@@ -118,7 +118,7 @@ module Bosh
                 expect(json['http_request_timeout']).to eq('30s')
               end
 
-              it 'omits http_request_timeout when not provided' do
+              it 'excludes http_request_timeout when not provided' do
                 set(link_props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -105,6 +105,29 @@ module Bosh
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
+
+              it 'passes http_request_timeout when provided' do
+                set(link_props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json['http_request_timeout']).to eq('30s')
+              end
+
+              it 'omits http_request_timeout when not provided' do
+                set(link_props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).not_to have_key('http_request_timeout')
+              end
             end
           end
         end

--- a/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
+++ b/spec/cc_deployment_updater/storage_cli_config_jsons_spec.rb
@@ -192,7 +192,8 @@ module Bosh
                       'single_upload_threshold' => 2048,
                       'request_checksum_calculation_enabled' => false,
                       'response_checksum_calculation_enabled' => false,
-                      'uploader_request_checksum_calculation_enabled' => false
+                      'uploader_request_checksum_calculation_enabled' => false,
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -222,7 +223,8 @@ module Bosh
                   'single_upload_threshold' => 2048,
                   'request_checksum_calculation_enabled' => false,
                   'response_checksum_calculation_enabled' => false,
-                  'uploader_request_checksum_calculation_enabled' => false
+                  'uploader_request_checksum_calculation_enabled' => false,
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -265,8 +267,8 @@ module Bosh
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
-                      'encryption_key' => 'key'
-
+                      'encryption_key' => 'key',
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -276,7 +278,8 @@ module Bosh
                   'json_key' => '{}',
                   'credentials_source' => 'static',
                   'storage_class' => 'STANDARD',
-                  'encryption_key' => 'key'
+                  'encryption_key' => 'key',
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -314,6 +317,19 @@ module Bosh
                   'endpoint' => 'alioss.com',
                   'bucket_name' => 'bucket'
                 )
+              end
+
+              it 'includes http_request_timeout when provided' do
+                set(link_props, keypath, {
+                      'provider' => 'alioss',
+                      'aliyun_accesskey_id' => 'key',
+                      'aliyun_accesskey_secret' => 'secret',
+                      'aliyun_oss_endpoint' => 'alioss.com',
+                      'aliyun_oss_bucket' => 'bucket',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).to include('http_request_timeout' => '30s')
               end
             end
           end

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -90,6 +90,29 @@ module Bosh
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
+
+              it 'passes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json['http_request_timeout']).to eq('30s')
+              end
+
+              it 'omits http_request_timeout when not provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).not_to have_key('http_request_timeout')
+              end
             end
           end
         end

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -91,7 +91,7 @@ module Bosh
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
 
-              it 'passes http_request_timeout when provided' do
+              it 'includes http_request_timeout when provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
@@ -103,7 +103,7 @@ module Bosh
                 expect(json['http_request_timeout']).to eq('30s')
               end
 
-              it 'omits http_request_timeout when not provided' do
+              it 'excludes http_request_timeout when not provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',

--- a/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_clock/storage_cli_config_jsons_spec.rb
@@ -169,7 +169,8 @@ module Bosh
                       'single_upload_threshold' => 2048,
                       'request_checksum_calculation_enabled' => false,
                       'response_checksum_calculation_enabled' => false,
-                      'uploader_request_checksum_calculation_enabled' => false
+                      'uploader_request_checksum_calculation_enabled' => false,
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -199,7 +200,8 @@ module Bosh
                   'single_upload_threshold' => 2048,
                   'request_checksum_calculation_enabled' => false,
                   'response_checksum_calculation_enabled' => false,
-                  'uploader_request_checksum_calculation_enabled' => false
+                  'uploader_request_checksum_calculation_enabled' => false,
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -234,8 +236,8 @@ module Bosh
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
-                      'encryption_key' => 'key'
-
+                      'encryption_key' => 'key',
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -245,7 +247,8 @@ module Bosh
                   'json_key' => '{}',
                   'credentials_source' => 'static',
                   'storage_class' => 'STANDARD',
-                  'encryption_key' => 'key'
+                  'encryption_key' => 'key',
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -275,6 +278,19 @@ module Bosh
                   'endpoint' => 'alioss.com',
                   'bucket_name' => 'bucket'
                 )
+              end
+
+              it 'includes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'alioss',
+                      'aliyun_accesskey_id' => 'key',
+                      'aliyun_accesskey_secret' => 'secret',
+                      'aliyun_oss_endpoint' => 'alioss.com',
+                      'aliyun_oss_bucket' => 'bucket',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).to include('http_request_timeout' => '30s')
               end
             end
           end

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -90,6 +90,29 @@ module Bosh
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
+
+              it 'passes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json['http_request_timeout']).to eq('30s')
+              end
+
+              it 'omits http_request_timeout when not provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).not_to have_key('http_request_timeout')
+              end
             end
           end
         end

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -91,7 +91,7 @@ module Bosh
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
 
-              it 'passes http_request_timeout when provided' do
+              it 'includes http_request_timeout when provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
@@ -103,7 +103,7 @@ module Bosh
                 expect(json['http_request_timeout']).to eq('30s')
               end
 
-              it 'omits http_request_timeout when not provided' do
+              it 'excludes http_request_timeout when not provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',

--- a/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_ng/storage_cli_config_jsons_spec.rb
@@ -169,7 +169,8 @@ module Bosh
                       'single_upload_threshold' => 2048,
                       'request_checksum_calculation_enabled' => false,
                       'response_checksum_calculation_enabled' => false,
-                      'uploader_request_checksum_calculation_enabled' => false
+                      'uploader_request_checksum_calculation_enabled' => false,
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -199,7 +200,8 @@ module Bosh
                   'single_upload_threshold' => 2048,
                   'request_checksum_calculation_enabled' => false,
                   'response_checksum_calculation_enabled' => false,
-                  'uploader_request_checksum_calculation_enabled' => false
+                  'uploader_request_checksum_calculation_enabled' => false,
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -234,8 +236,8 @@ module Bosh
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
-                      'encryption_key' => 'key'
-
+                      'encryption_key' => 'key',
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -245,7 +247,8 @@ module Bosh
                   'json_key' => '{}',
                   'credentials_source' => 'static',
                   'storage_class' => 'STANDARD',
-                  'encryption_key' => 'key'
+                  'encryption_key' => 'key',
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -275,6 +278,19 @@ module Bosh
                   'endpoint' => 'alioss.com',
                   'bucket_name' => 'bucket'
                 )
+              end
+
+              it 'includes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'alioss',
+                      'aliyun_accesskey_id' => 'key',
+                      'aliyun_accesskey_secret' => 'secret',
+                      'aliyun_oss_endpoint' => 'alioss.com',
+                      'aliyun_oss_bucket' => 'bucket',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).to include('http_request_timeout' => '30s')
               end
             end
           end

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -90,6 +90,29 @@ module Bosh
                 json = YAML.safe_load(template.render(props, consumes: links))
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
+
+              it 'passes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json['http_request_timeout']).to eq('30s')
+              end
+
+              it 'omits http_request_timeout when not provided' do
+                set(props, keypath, {
+                      'provider' => 'azurebs',
+                      'azure_storage_account_name' => 'acc',
+                      'azure_storage_access_key' => 'key',
+                      'container_name' => 'cont'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).not_to have_key('http_request_timeout')
+              end
             end
           end
         end

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -91,7 +91,7 @@ module Bosh
                 expect(json['put_timeout_in_seconds']).to eq('7')
               end
 
-              it 'passes http_request_timeout when provided' do
+              it 'includes http_request_timeout when provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',
@@ -103,7 +103,7 @@ module Bosh
                 expect(json['http_request_timeout']).to eq('30s')
               end
 
-              it 'omits http_request_timeout when not provided' do
+              it 'excludes http_request_timeout when not provided' do
                 set(props, keypath, {
                       'provider' => 'azurebs',
                       'azure_storage_account_name' => 'acc',

--- a/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
+++ b/spec/cloud_controller_worker/storage_cli_config_jsons_spec.rb
@@ -169,7 +169,8 @@ module Bosh
                       'single_upload_threshold' => 2048,
                       'request_checksum_calculation_enabled' => false,
                       'response_checksum_calculation_enabled' => false,
-                      'uploader_request_checksum_calculation_enabled' => false
+                      'uploader_request_checksum_calculation_enabled' => false,
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -199,7 +200,8 @@ module Bosh
                   'single_upload_threshold' => 2048,
                   'request_checksum_calculation_enabled' => false,
                   'response_checksum_calculation_enabled' => false,
-                  'uploader_request_checksum_calculation_enabled' => false
+                  'uploader_request_checksum_calculation_enabled' => false,
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -234,8 +236,8 @@ module Bosh
                       'bucket_name' => 'bucket',
                       'google_json_key_string' => '{}',
                       'storage_class' => 'STANDARD',
-                      'encryption_key' => 'key'
-
+                      'encryption_key' => 'key',
+                      'http_request_timeout' => '30s'
                     })
 
                 json = YAML.safe_load(template.render(props, consumes: links))
@@ -245,7 +247,8 @@ module Bosh
                   'json_key' => '{}',
                   'credentials_source' => 'static',
                   'storage_class' => 'STANDARD',
-                  'encryption_key' => 'key'
+                  'encryption_key' => 'key',
+                  'http_request_timeout' => '30s'
                 )
               end
             end
@@ -275,6 +278,19 @@ module Bosh
                   'endpoint' => 'alioss.com',
                   'bucket_name' => 'bucket'
                 )
+              end
+
+              it 'includes http_request_timeout when provided' do
+                set(props, keypath, {
+                      'provider' => 'alioss',
+                      'aliyun_accesskey_id' => 'key',
+                      'aliyun_accesskey_secret' => 'secret',
+                      'aliyun_oss_endpoint' => 'alioss.com',
+                      'aliyun_oss_bucket' => 'bucket',
+                      'http_request_timeout' => '30s'
+                    })
+                json = YAML.safe_load(template.render(props, consumes: links))
+                expect(json).to include('http_request_timeout' => '30s')
               end
             end
           end


### PR DESCRIPTION
Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Allow configuration of http request timeouts for the storage-cli.

* An explanation of the use cases your change solves

By default, storage-cli has only TCP connection timeout settings. To handle unresponsive http servers, it can be necessary to implement http client request timeouts.

* Links to any other associated PRs

https://github.com/cloudfoundry/storage-cli/pull/156
https://github.com/cloudfoundry/storage-cli/pull/176
https://github.com/cloudfoundry/storage-cli/pull/183

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite

I've run the cf-smoke tests on an AWS dev landscape.