### PR TITLE
Add ccdb.ssl_mode property to CC jobs

### DIFF
--- a/jobs/blobstore_benchmark/templates/cloud_controller_ng.yml.erb
+++ b/jobs/blobstore_benchmark/templates/cloud_controller_ng.yml.erb
@@ -99,6 +99,8 @@
     db_hash['ca_cert_path'] = '/var/vcap/jobs/blobstore_benchmark/config/certs/db_ca.crt'
   end
 
+  link("cloud_controller_db").if_p("ccdb.ssl_mode") { |ssl_mode| db_hash['ssl_mode'] = ssl_mode }
+
   benchmark_logging_level = p("blobstore_benchmark.logging_level", "info")
   benchmark_stdout_sink   = p("blobstore_benchmark.stdout_sink_enabled", false)
 

--- a/jobs/cc_deployment_updater/spec
+++ b/jobs/cc_deployment_updater/spec
@@ -81,6 +81,8 @@ properties:
   ccdb.ssl_verify_hostname:
     default: true
     description: "Verify that the database SSL certificate matches the host to which the connection is attempted"
+  ccdb.ssl_mode:
+    description: "Explicit SSL mode for the DB connection, used only when ccdb.ca_cert is not set. MySQL: disabled or required. Postgres: disable, allow, prefer, or require."
   ccdb.read_timeout:
     default: 3600
     description: "The read timeout in seconds for query responses, passed directly to the Sequel gem - see https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc for details"

--- a/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb
@@ -67,6 +67,9 @@ db: &db
   log_level: "<%= p("cc.db_logging_level") %>"
   log_db_queries: <%= p("cc.log_db_queries") %>
   ssl_verify_hostname: <%= p("ccdb.ssl_verify_hostname") %>
+<% if_p('ccdb.ssl_mode') do |ssl_mode| %>
+  ssl_mode: <%= ssl_mode %>
+<% end %>
   read_timeout: <%= p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= p("ccdb.connection_validation_timeout") %>
 <% if_p('ccdb.ca_cert') do %>

--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -404,6 +404,8 @@ properties:
   ccdb.ssl_verify_hostname:
     default: true
     description: "Verify that the database SSL certificate matches the host to which the connection is attempted"
+  ccdb.ssl_mode:
+    description: "Explicit SSL mode for the DB connection, used only when ccdb.ca_cert is not set. MySQL: disabled or required. Postgres: disable, allow, prefer, or require."
   ccdb.read_timeout:
     default: 3600
     description: "The read timeout in seconds for query responses, passed directly to the Sequel gem - see https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc for details"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -171,6 +171,9 @@ db: &db
   log_level: "<%= p("cc.db_logging_level") %>"
   log_db_queries: <%= p("cc.log_db_queries") %>
   ssl_verify_hostname: <%= p("ccdb.ssl_verify_hostname") %>
+<% if_p('ccdb.ssl_mode') do |ssl_mode| %>
+  ssl_mode: <%= ssl_mode %>
+<% end %>
   read_timeout: <%= p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= p("ccdb.connection_validation_timeout") %>
 <% if_p('ccdb.ca_cert') do %>

--- a/jobs/cloud_controller_ng/spec
+++ b/jobs/cloud_controller_ng/spec
@@ -97,6 +97,7 @@ provides:
   - ccdb.read_timeout
   - ccdb.ssl_verify_hostname
   - ccdb.ca_cert
+  - ccdb.ssl_mode
 - name: directories_to_backup
   type: directories_to_backup
   properties:
@@ -757,6 +758,8 @@ properties:
   ccdb.ssl_verify_hostname:
     default: true
     description: "Verify that the database SSL certificate matches the host to which the connection is attempted"
+  ccdb.ssl_mode:
+    description: "Explicit SSL mode for the DB connection, used only when ccdb.ca_cert is not set. MySQL: disabled or required. Postgres: disable, allow, prefer, or require."
   ccdb.read_timeout:
     default: 3600
     description: "The read timeout in seconds for query responses, passed directly to the Sequel gem - see https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc for details"

--- a/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -227,6 +227,9 @@ db: &db
   query_size_log_threshold: <%= p("cc.query_size_log_threshold") %>
 <% end %>
   ssl_verify_hostname: <%= p("ccdb.ssl_verify_hostname") %>
+<% if_p("ccdb.ssl_mode") do |ssl_mode| %>
+  ssl_mode: <%= ssl_mode %>
+<% end %>
   read_timeout: <%= p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= p("ccdb.connection_validation_timeout") %>
 <% if_p("ccdb.ca_cert") do %>

--- a/jobs/cloud_controller_worker/spec
+++ b/jobs/cloud_controller_worker/spec
@@ -361,6 +361,8 @@ properties:
   ccdb.ssl_verify_hostname:
     default: true
     description: "Verify that the database SSL certificate matches the host to which the connection is attempted"
+  ccdb.ssl_mode:
+    description: "Explicit SSL mode for the DB connection, used only when ccdb.ca_cert is not set. MySQL: disabled or required. Postgres: disable, allow, prefer, or require."
   ccdb.read_timeout:
     default: 3600
     description: "The read timeout in seconds for query responses, passed directly to the Sequel gem - see https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc for details"

--- a/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -123,6 +123,9 @@ db: &db
   log_level: "<%= p("cc.db_logging_level") %>"
   log_db_queries: <%= p("cc.log_db_queries") %>
   ssl_verify_hostname: <%= p("ccdb.ssl_verify_hostname") %>
+  <% if_p("ccdb.ssl_mode") do |ssl_mode| %>
+  ssl_mode: <%= ssl_mode %>
+  <% end %>
   read_timeout: <%= p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= p("ccdb.connection_validation_timeout") %>
   <% if_p("ccdb.ca_cert") do %>

--- a/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
+++ b/jobs/rotate_cc_database_key/templates/cloud_controller_ng.yml.erb
@@ -67,6 +67,9 @@ db: &db
   log_level: "<%= p("cc.db_logging_level", link("cloud_controller_internal").p("cc.db_logging_level")) %>"
   log_db_queries: <%= p("cc.log_db_queries", link("cloud_controller_internal").p("cc.log_db_queries")) %>
   ssl_verify_hostname: <%= link("cloud_controller_db").p("ccdb.ssl_verify_hostname") %>
+<% link("cloud_controller_db").if_p('ccdb.ssl_mode') do |ssl_mode| %>
+  ssl_mode: <%= ssl_mode %>
+<% end %>
   read_timeout: <%= link("cloud_controller_db").p("ccdb.read_timeout") %>
   connection_validation_timeout: <%= link("cloud_controller_db").p("ccdb.connection_validation_timeout") %>
 <% link("cloud_controller_db").if_p('ccdb.ca_cert') do %>

--- a/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
+++ b/spec/cloud_controller_ng/cloud_controller_ng_spec.rb
@@ -504,6 +504,24 @@ module Bosh
             end
           end
 
+          context 'when ccdb.ssl_mode is set' do
+            before do
+              merged_manifest_properties['ccdb']['ssl_mode'] = 'required'
+            end
+
+            it 'renders ssl_mode into the db block' do
+              template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+              expect(template_hash['db']['ssl_mode']).to eq('required')
+            end
+          end
+
+          context 'when ccdb.ssl_mode is not set' do
+            it 'does not render an ssl_mode key' do
+              template_hash = YAML.safe_load(template.render(merged_manifest_properties, consumes: links))
+              expect(template_hash['db']).not_to have_key('ssl_mode')
+            end
+          end
+
           context 'when the file_server link is present' do
             let(:links) { [db_link, file_server_link] }
 


### PR DESCRIPTION
Expose an optional `ccdb.ssl_mode` BOSH property on all four jobs that render the CC database config (cloud_controller_ng, worker, clock, cc_deployment_updater). It is rendered into the db block only when set.

Export `ccdb.ssl_mode` via the `cloud_controller_db` link and render it in the jobs that read the DB config through that link (blobstore_benchmark, rotate_cc_database_key), so they stay consistent with the main jobs.

This lets operators pin the DB SSL mode when no `ccdb.ca_cert` is configured. Consumed by the CCNG `db_connection` option factories.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
