### PR TITLE
Restore legacy default for mariadb-connector-c server cert verification

### DIFF
--- a/packages/mariadb_connector_c/packaging
+++ b/packages/mariadb_connector_c/packaging
@@ -7,7 +7,7 @@ tar xzf mariadb_connector_c/mariadb-connector-c-${VERSION}-src.tar.gz
 pushd mariadb-connector-c-${VERSION}-src > /dev/null
 	mkdir bld
 	cd bld
-	cmake .. -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
+	cmake .. -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF -DDEFAULT_SSL_VERIFY_SERVER_CERT=OFF
 	make
 	make install
 popd > /dev/null


### PR DESCRIPTION
mysql2 never explicitly sets MYSQL_OPT_SSL_VERIFY_SERVER_CERT, so it inherits whatever default mariadb-connector-c compiles in. 

Starting with connector-c 3.4.0, that default flipped to verify the server cert (https://mariadb.com/docs?q=mariadb-connector-c-3-4-0-release-notes), which breaks ccdb connections for deployments that don't configure a CA cert (https://github.com/brianmario/mysql2/issues/1379). 

Building with -DDEFAULT_SSL_VERIFY_SERVER_CERT=OFF restores the pre-3.4 default of not verifying, while leaving explicit TLS configuration untouched.

Suggestion from https://github.com/brianmario/mysql2/issues/1379#issuecomment-2427434941 

Thanks for contributing to the `capi_release`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
