### PR TITLE
Remove lifecycle_type_backfill job config and BOSH property

### DIFF
--- a/jobs/cloud_controller_clock/spec
+++ b/jobs/cloud_controller_clock/spec
@@ -149,11 +149,6 @@ properties:
     description: "How often operations stuck in state 'in progress' should be cleaned up."
     default: 3600 # 1 hour
 
-  # One-off backfill - to be removed in a future version.
-  cc.lifecycle_type_backfill.frequency_in_seconds:
-    description: "How often the one-off lifecycle_type backfill job runs"
-    default: 3600 # 1 hour
-
   cc.external_protocol:
     default: "https"
     description: "The protocol used to access the CC API from an external entity"

--- a/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -127,10 +127,6 @@ pending_builds:
 diego_sync:
   frequency_in_seconds: <%= p("cc.diego_sync.frequency_in_seconds") %>
 
-# One-off backfill - to be removed in a future version.
-lifecycle_type_backfill:
-  frequency_in_seconds: <%= p("cc.lifecycle_type_backfill.frequency_in_seconds") %>
-
 nginx:
   use_nginx: true
   instance_socket: "/var/vcap/sys/run/cloud_controller_clock/cloud_controller.sock"


### PR DESCRIPTION
* A short explanation of the proposed change:

   Removes the `cc.lifecycle_type_backfill.frequency_in_seconds `BOSH property and its corresponding entry in the cloud_controller_ng.yml.erb template. This job was a one-off backfill introduced to populate NULL lifecycle_type values and is no longer needed.

* An explanation of the use cases your change solves
  Cleans up the temporary backfill job configuration from capi-release once all installations have had sufficient time to run it. Without this change, BOSH would pass a config key to CC that CC no longer recognizes after the corresponding CC change

* Links to any other associated PRs
  https://github.com/cloudfoundry/cloud_controller_ng/pull/5401
  https://github.com/cloudfoundry/cloud_controller_ng/pull/5402
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have run CF Acceptance Tests on bosh lite
